### PR TITLE
fix: validate site domain before it reaches nginx server_name

### DIFF
--- a/packages/ts-cloud/src/deploy/local-dashboard-server.ts
+++ b/packages/ts-cloud/src/deploy/local-dashboard-server.ts
@@ -40,7 +40,7 @@ import {
   setServerlessSecret,
   updateFunctionConfig,
 } from './serverless-operations'
-import { addSiteToCloudConfig, removeSiteFromCloudConfig, renderAliasesValue, renderEnvValue, renderRedirectsValue, renderSslValue, renderStringValue, setSitePropertyInCloudConfig } from './site-config-editor'
+import { addSiteToCloudConfig, isValidHostname, removeSiteFromCloudConfig, renderAliasesValue, renderEnvValue, renderRedirectsValue, renderSslValue, renderStringValue, setSitePropertyInCloudConfig } from './site-config-editor'
 import { addSshKeyToCloudConfig, describeSshKeys, removeSshKeyFromCloudConfig } from './ssh-config-editor'
 import { createTerminalSession } from './terminal-session'
 
@@ -859,6 +859,15 @@ export async function startLocalDashboardServer(options: LocalDashboardServerOpt
 
           if (body.port !== undefined && body.port !== null && body.port !== '' && (!Number.isInteger(Number(body.port)) || Number(body.port) < 1 || Number(body.port) > 65_535))
             return json({ ok: false, error: 'Port must be a number between 1 and 65535.' }, 422)
+
+          // `domain` lands in the generated nginx `server_name`, so it must be a
+          // hostname and nothing else — an unvalidated value can close the
+          // server block and open an attacker-controlled one. `aliases` (same
+          // destination) has always been checked; this closes the gap for the
+          // primary domain. Validated before any write so a bad value can't
+          // leave the config half-edited.
+          if (typeof body.domain === 'string' && body.domain.trim() && !isValidHostname(body.domain.trim()))
+            return json({ ok: false, error: `Domain '${body.domain.trim()}' is not a valid hostname.` }, 422)
 
           let text = await readFile(configPath, 'utf8')
           const set = (key: string, valueText: string): void => {

--- a/packages/ts-cloud/src/deploy/management-dashboard.ts
+++ b/packages/ts-cloud/src/deploy/management-dashboard.ts
@@ -97,10 +97,16 @@ export function resolveDashboardAuth(cwd: string, username: string, logger: Ensu
     mkdirSync(dirname(file), { recursive: true })
     writeFileSync(file, `${JSON.stringify({ username, password, generatedAt: new Date().toISOString() }, null, 2)}\n`)
     chmodSync(file, 0o600)
-    logger.info(`Management dashboard: generated a password and saved it to ${DASHBOARD_CREDENTIALS_FILE} (user: ${username}, pass: ${password}). Set TS_CLOUD_UI_PASSWORD to pin your own, or TS_CLOUD_UI_PUBLIC=1 to serve without auth.`)
+    // Deliberately NOT logging the password: deploy output lands in CI logs,
+    // terminal scrollback and the systemd journal, all of which outlive the
+    // deploy and are readable by more people than the 0600 file is.
+    logger.info(`Management dashboard: generated a password for '${username}' and saved it to ${DASHBOARD_CREDENTIALS_FILE} (read it there — it is not printed). Set TS_CLOUD_UI_PASSWORD to pin your own, or TS_CLOUD_UI_PUBLIC=1 to serve without auth.`)
   }
   catch (error: any) {
-    logger.warn(`Management dashboard: could not persist the generated password (${error?.message ?? error}). Using it for this deploy only — pass: ${password}`)
+    // Only place the password is still printed: persisting failed, so this log
+    // line is the operator's single copy. Say plainly that it is now in the log
+    // so they can rotate it once the underlying write problem is fixed.
+    logger.warn(`Management dashboard: could not persist the generated password (${error?.message ?? error}). Using it for this deploy only — pass: ${password}\nThis password is now in your deploy log. Set TS_CLOUD_UI_PASSWORD to a value of your own and redeploy once ${DASHBOARD_CREDENTIALS_FILE} is writable.`)
   }
   return { password, source: 'generated' }
 }

--- a/packages/ts-cloud/src/deploy/site-config-editor.ts
+++ b/packages/ts-cloud/src/deploy/site-config-editor.ts
@@ -236,7 +236,16 @@ export function renderSiteSnippet(input: Omit<AddSiteConfigInput, 'configText'>)
 }
 
 function escapeSingle(value: string): string {
-  return value.replace(/\\/g, '\\\\').replaceAll(String.fromCharCode(39), '\\\'')
+  // Newlines matter as much as quotes here: these values land in single-quoted
+  // TS string literals in the shared, box-wide cloud.config.ts. A raw newline
+  // terminates the literal and leaves the file syntactically broken for every
+  // tenant that loads it. It also keeps line-oriented sinks downstream (heredoc
+  // delimiters in the deploy script) safe from values that span lines.
+  return value
+    .replace(/\\/g, '\\\\')
+    .replaceAll(String.fromCharCode(39), '\\\'')
+    .replace(/\r/g, '\\r')
+    .replace(/\n/g, '\\n')
 }
 
 function normalizeSiteName(name: string): string {

--- a/packages/ts-cloud/src/drivers/shared/nginx-vhost.ts
+++ b/packages/ts-cloud/src/drivers/shared/nginx-vhost.ts
@@ -269,7 +269,24 @@ function vhostBody(options: NginxVhostOptions): string[] {
  * otherwise a single :80 block (certbot upgrades it for Let's Encrypt).
  */
 export function buildNginxVhost(options: NginxVhostOptions): string {
-  const serverNames = [options.domain, ...(options.aliases || [])].filter(Boolean).join(' ')
+  const hosts = [options.domain, ...(options.aliases || [])].filter(Boolean) as string[]
+  // Defense in depth: every token here is interpolated straight into a
+  // `server_name` directive, and nginx is whitespace-insensitive — so anything
+  // that isn't a bare hostname could close this block and open another. Callers
+  // validate too; refuse here as well so no future path can slip a directive in.
+  //
+  // Deliberately laxer than `isValidHostname` (which the dashboard API uses for
+  // user-supplied domains and which requires a dot): a single label is valid
+  // here because compute-deploy falls back to `site.domain || siteName`, so an
+  // internal site legitimately arrives as `main` or `docs`. What matters for
+  // safety is only that a token can't contain whitespace, `;`, `{` or `}`.
+  for (const host of hosts) {
+    if (!/^(?=.{1,253}$)(?:\*\.)?[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$/i.test(host.trim()))
+      throw new Error(`Refusing to build a vhost: '${host}' is not a valid hostname.`)
+  }
+  if (!hosts.length)
+    throw new Error('Refusing to build a vhost: no server_name (domain) was given.')
+  const serverNames = hosts.join(' ')
   const body = vhostBody(options)
 
   if (options.ssl) {

--- a/packages/ts-cloud/test/drivers/nginx-vhost-injection.test.ts
+++ b/packages/ts-cloud/test/drivers/nginx-vhost-injection.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'bun:test'
+import { isValidHostname, renderStringValue } from '../../src/deploy/site-config-editor'
+import { buildNginxVhost } from '../../src/drivers/shared/nginx-vhost'
+
+/**
+ * Regression tests for nginx `server_name` injection.
+ *
+ * A site's `domain` is member-editable and is interpolated straight into the
+ * generated `server_name` directive. nginx is whitespace-insensitive, so an
+ * unvalidated value can close the server block and open an attacker-controlled
+ * one — e.g. `location / { root /; autoindex on; }`, which exposes the whole
+ * filesystem (other tenants' .env files, the dashboard user store, SSH keys)
+ * over HTTP on a shared box.
+ */
+
+// Closes the generated block, opens a filesystem-exposing one, then reopens a
+// server block so the result still parses.
+const INJECTION = 'x.com; } location / { root /; autoindex on; } server { server_name y.com'
+
+describe('server_name injection', () => {
+  it('rejects a domain carrying nginx directives', () => {
+    expect(isValidHostname(INJECTION)).toBe(false)
+  })
+
+  it('refuses to build a vhost from an injected domain', () => {
+    expect(() => buildNginxVhost({
+      siteName: 'app',
+      domain: INJECTION,
+      appDir: '/var/www/app/current',
+    })).toThrow(/not a valid hostname/)
+  })
+
+  it('refuses to build a vhost from an injected alias', () => {
+    expect(() => buildNginxVhost({
+      siteName: 'app',
+      domain: 'example.com',
+      aliases: [INJECTION],
+      appDir: '/var/www/app/current',
+    })).toThrow(/not a valid hostname/)
+  })
+
+  it('rejects whitespace, newlines and directive punctuation in a hostname', () => {
+    for (const bad of ['a.com b.com', 'a.com\nserver_name evil.com', 'a.com;', 'a.com{', 'a.com}']) {
+      expect(() => buildNginxVhost({
+        siteName: 'app',
+        domain: bad,
+        appDir: '/var/www/app/current',
+      })).toThrow(/not a valid hostname/)
+    }
+  })
+
+  it('rejects an empty server_name rather than emitting `server_name ;`', () => {
+    expect(() => buildNginxVhost({
+      siteName: 'app',
+      domain: '',
+      appDir: '/var/www/app/current',
+    })).toThrow(/no server_name/)
+  })
+
+  // compute-deploy falls back to `domain: site.domain || siteName`, so an
+  // internal site with no configured domain arrives here as a single label.
+  // The generator must keep accepting those or every such deploy breaks.
+  it('accepts a single-label host (the siteName fallback)', () => {
+    for (const host of ['main', 'docs', 'localhost']) {
+      const vhost = buildNginxVhost({
+        siteName: host,
+        domain: host,
+        appDir: '/var/www/app/current',
+      })
+      expect(vhost).toContain(`server_name ${host};`)
+    }
+  })
+
+  it('still builds a normal vhost, including wildcard aliases', () => {
+    const vhost = buildNginxVhost({
+      siteName: 'app',
+      domain: 'app.example.com',
+      aliases: ['www.example.com', '*.cdn.example.com'],
+      appDir: '/var/www/app/current',
+    })
+    expect(vhost).toContain('server_name app.example.com www.example.com *.cdn.example.com;')
+  })
+})
+
+describe('cloud.config.ts string escaping', () => {
+  it('escapes newlines so a value cannot terminate the string literal', () => {
+    const rendered = renderStringValue('a\nb')
+    expect(rendered).not.toContain('\n')
+    expect(rendered).toBe('\'a\\nb\'')
+  })
+
+  it('escapes carriage returns, quotes and backslashes', () => {
+    expect(renderStringValue('a\rb')).not.toContain('\r')
+    expect(renderStringValue('it\'s')).toBe('\'it\\\'s\'')
+    expect(renderStringValue('a\\b')).toBe('\'a\\\\b\'')
+  })
+})


### PR DESCRIPTION
Hardening for values that flow from the dashboard into generated server config.

### `domain` → nginx `server_name`

A site's `domain` is member-editable and was written into the generated `server_name` with quote-escaping only, while its sibling `aliases` — same destination — was validated with `isValidHostname`. This closes that asymmetry:

- validate `domain` on `PATCH /api/sites` **before any write**, so a rejected value can't leave `cloud.config.ts` half-edited
- reject non-hostname tokens inside `buildNginxVhost` as defense in depth, so no other path can introduce one
- refuse an empty `server_name` instead of emitting `server_name ;` (invalid nginx)

The generator's check is deliberately **laxer** than the API's: `compute-deploy` falls back to `domain: site.domain || siteName`, so an internal site legitimately arrives as a single label (`main`, `docs`). A test pins that so the stricter API rule can't leak into the generator and break those deploys.

### `escapeSingle` now escapes `\r` / `\n`

These values land in single-quoted TS literals in the shared, box-wide `cloud.config.ts`. A raw newline terminates the literal and leaves the file syntactically broken for every tenant that loads it. Escaping also keeps line-oriented sinks downstream (heredoc delimiters in the deploy script) safe from multi-line values.

### Dashboard password no longer logged

The generated Basic-auth password was written to the 0600 credentials file *and* logged in full on every successful deploy — and deploy output outlives the deploy in CI logs, scrollback and the journal. Now logs the path. The failure path still prints it (persisting failed, so it's the only copy) but says so and tells you to rotate.

### Tests

Adds `test/drivers/nginx-vhost-injection.test.ts` (9 tests): injection payloads rejected in both `domain` and `aliases`, whitespace/newline/`;`/`{`/`}` rejected, empty `server_name` rejected, single-label fallback still accepted, and escaping of newlines/CR/quotes/backslashes.

Baseline on `main` is 249 pass / 15 fail; this branch is 258 pass / 15 fail — the same 15 pre-existing module-resolution failures (`@stacksjs/ts-xml`, `bunfig` aren't installed in the checkout), no regressions.
