### PR TITLE
fix(dashboard): confirm destructive actions that ran on first click

### DIFF
--- a/packages/ui/pages/server/actions.stx
+++ b/packages/ui/pages/server/actions.stx
@@ -39,12 +39,29 @@ const serverCmd = state('')
 const cmdOut = state('')
 const cmdShown = state(false)
 const cmdBusy = state(false)
-async function runServerCmd() {
+// The API already requires a typed confirmation for shell commands — it answers
+// 'Type "run" to execute this command on the server.' The UI never implemented
+// that step and supplied the token itself, so the gate always passed and Enter
+// in the box ran arbitrary shell on the production server. Stage the command,
+// make the operator type the word, and send what they actually typed.
+const cmdPending = state(null)
+const cmdTyped = state('')
+const cmdCanRun = derived(() => cmdPending() !== null && cmdTyped().trim() === 'run')
+function askServerCmd() {
   const c = serverCmd().trim()
   if (!c) return
+  cmdPending.set(c); cmdTyped.set('')
+}
+function cancelServerCmd() { cmdPending.set(null); cmdTyped.set('') }
+
+async function runServerCmd() {
+  const c = cmdPending()
+  const confirm = cmdTyped().trim()
+  if (!c || confirm !== 'run') return
+  cmdPending.set(null); cmdTyped.set('')
   cmdBusy.set(true); cmdShown.set(true); cmdOut.set('Running ' + c + '...')
   try {
-    const res = await fetch('/api/server/command', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ command: c, confirm: 'run' }) })
+    const res = await fetch('/api/server/command', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ command: c, confirm }) })
     const b = await res.json()
     cmdOut.set((b.ok ? 'OK ' : 'FAILED ') + (b.command || c) + '\n\n' + (b.stdout || '') + (b.stderr ? '\n' + b.stderr : '') + (b.error ? '\n' + b.error : ''))
   } catch (e) { cmdOut.set('FAILED ' + c + '\n\n' + ((e && e.message) || e)) }
@@ -81,8 +98,14 @@ async function runServerCmd() {
       <h2>Run a command on the server</h2>
       <div class="panel">
         <div class="field">
-          <input :value="serverCmd()" @input="serverCmd.set($event.target.value)" @keydown.enter="runServerCmd()" placeholder="e.g. systemctl status rpx-gateway, or df -h" autocomplete="off">
-          <button class="btn" type="button" :disabled="cmdBusy()" @click="runServerCmd()">Run</button>
+          <input :value="serverCmd()" @input="serverCmd.set($event.target.value)" @keydown.enter="askServerCmd()" placeholder="e.g. systemctl status rpx-gateway, or df -h" autocomplete="off" aria-label="Command to run on the server">
+          <button class="btn" type="button" :disabled="cmdBusy()" @click="askServerCmd()">Run</button>
+        </div>
+        <div class="op-confirm" @show="cmdPending() !== null" style="margin-top:14px">
+          <span>Type <b class="mono">run</b> to execute <b class="mono">{{ cmdPending() }}</b> on {{ server.name }}:</span>
+          <input class="op-confirm-input" :value="cmdTyped()" @input="cmdTyped.set($event.target.value)" @keydown.enter="runServerCmd()" placeholder="confirm" autocomplete="off" aria-label="Type run to confirm executing this command">
+          <button type="button" class="btn danger sm" :disabled="!cmdCanRun()" @click="runServerCmd()">Run command</button>
+          <button type="button" class="btn ghost sm" @click="cancelServerCmd()">Cancel</button>
         </div>
         <pre class="action-output" @show="cmdShown()">{{ cmdOut() }}</pre>
         <p class="note">Runs on the app box over the active driver (SSH/SSM). Use it for one-off recipes, service inspection, or installing software. Prefer declarative config for anything you want reproduced on the next deploy.</p>

--- a/packages/ui/pages/server/ssh-keys.stx
+++ b/packages/ui/pages/server/ssh-keys.stx
@@ -38,6 +38,21 @@ async function removeKey(n) {
   keys.set(data.keys || [])
   setMessage('Removed from cloud config. Run cloud deploy to apply.', 'ok')
 }
+// Removal runs through a typed-confirm bar (same pattern as firewall/team):
+// type the key name to confirm. Removing the wrong key can lock every operator
+// out of the box, so it should never be one misclick away.
+const pendingRemove = state(null)
+const typedRemove = state('')
+const canRemove = derived(() => { const k = pendingRemove(); return k !== null && typedRemove() === String(k.name) })
+function askRemove(key) { pendingRemove.set(key); typedRemove.set('') }
+function cancelRemove() { pendingRemove.set(null); typedRemove.set('') }
+async function confirmRemove() {
+  const k = pendingRemove()
+  if (!k || typedRemove() !== String(k.name)) return
+  pendingRemove.set(null); typedRemove.set('')
+  await removeKey(k.name)
+}
+
 onMount(() => { load() })
 </script>
 <!DOCTYPE html>
@@ -79,12 +94,18 @@ onMount(() => { load() })
                 <td class="mono" style="color:var(--txt3)">{{ k.type }}</td>
                 <td class="mono">{{ k.fingerprint }}</td>
                 <td style="color:var(--txt3)">{{ k.added }}</td>
-                <td class="table-actions"><button type="button" class="btn danger sm" @click="removeKey(k.name)">Remove</button></td>
+                <td class="table-actions"><button type="button" class="btn danger sm" :aria-label="'Remove SSH key ' + k.name" @click="askRemove(k)">Remove</button></td>
               </tr>
             </template>
           </tbody>
         </table>
         <div class="compact empty" @show="keys().length === 0"><strong>No SSH keys configured</strong><span>Add a public key above to update <span class="mono">infrastructure.compute.sshKeys</span>.</span></div>
+        <div class="op-confirm" @show="pendingRemove() !== null" style="margin-top:14px">
+          <span>Type <b class="mono">{{ pendingRemove()?.name }}</b> to remove this key from the box:</span>
+          <input class="op-confirm-input" :value="typedRemove()" @input="typedRemove.set($event.target.value)" @keydown.enter="confirmRemove()" placeholder="confirm" autocomplete="off" aria-label="Type the key name to confirm removal">
+          <button type="button" class="btn danger sm" :disabled="!canRemove()" @click="confirmRemove()">Remove</button>
+          <button type="button" class="btn ghost sm" @click="cancelRemove()">Cancel</button>
+        </div>
         <p class="note">Keys are declarative: this page edits <span class="mono">infrastructure.compute.sshKeys</span> in cloud config. Run <span class="mono">cloud deploy</span> to apply changes to the box. Connect with <span class="mono">cloud server:ssh {{ server.name }}</span>.</p>
       </div>
     </div>

--- a/packages/ui/pages/server/team.stx
+++ b/packages/ui/pages/server/team.stx
@@ -67,6 +67,22 @@ async function revoke(name) {
   load()
 }
 
+// Removal runs through a typed-confirm bar (same pattern as firewall/secrets):
+// type the username to confirm. Revoking pulls someone's access to every site
+// on the box at once and invalidates their password, so it should never be one
+// misclick away.
+const pendingRevoke = state(null)
+const typedRevoke = state('')
+const canRevoke = derived(() => { const u = pendingRevoke(); return u !== null && typedRevoke() === String(u.username) })
+function askRevoke(user) { pendingRevoke.set(user); typedRevoke.set('') }
+function cancelRevoke() { pendingRevoke.set(null); typedRevoke.set('') }
+async function confirmRevoke() {
+  const u = pendingRevoke()
+  if (!u || typedRevoke() !== String(u.username)) return
+  pendingRevoke.set(null); typedRevoke.set('')
+  await revoke(u.username)
+}
+
 onMount(() => { load() })
 </script>
 <!DOCTYPE html>
@@ -135,12 +151,18 @@ onMount(() => { load() })
                 <td><b>{{ u.name }}</b><span class="mono uname">{{ u.username }}</span></td>
                 <td><span class="tag">{{ u.role === 'admin' ? 'box owner' : 'member' }}</span></td>
                 <td class="mono">{{ u.role === 'admin' ? 'every site' : siteList(u) }}</td>
-                <td class="table-actions"><button type="button" class="btn danger sm" @click="revoke(u.username)">Remove</button></td>
+                <td class="table-actions"><button type="button" class="btn danger sm" @click="askRevoke(u)">Remove</button></td>
               </tr>
             </template>
           </tbody>
         </table>
         <div class="compact empty" @show="users().length === 0"><strong>No one invited yet</strong><span>Invite someone above to give them access to a site.</span></div>
+        <div class="op-confirm" @show="pendingRevoke() !== null" style="margin-top:14px">
+          <span>Type <b class="mono">{{ pendingRevoke()?.username }}</b> to remove <b>{{ pendingRevoke()?.name }}</b> from every site:</span>
+          <input class="op-confirm-input" :value="typedRevoke()" @input="typedRevoke.set($event.target.value)" @keydown.enter="confirmRevoke()" placeholder="confirm" autocomplete="off">
+          <button class="btn danger sm" :disabled="!canRevoke()" @click="confirmRevoke()">Remove</button>
+          <button class="btn ghost sm" @click="cancelRevoke()">Cancel</button>
+        </div>
         <p class="note">Box owners reach everything on this server. Members reach only the sites listed here, and never the shell, SSH keys, firewall or databases. Access is checked on every request.</p>
       </div>
     </div>

--- a/packages/ui/pages/serverless.stx
+++ b/packages/ui/pages/serverless.stx
@@ -87,12 +87,29 @@ const appCmd = state('')
 const cmdOut = state('')
 const cmdShown = state(false)
 const cmdBusy = state(false)
-async function runAppCmd() {
+// The API already requires a typed confirmation here ('Type "run" to execute
+// this command.'), but the UI supplied the token itself, so the gate always
+// passed and Enter ran an arbitrary app command (migrate:fresh, queue:flush)
+// against production. Stage it, make the operator type the word, send what they
+// actually typed.
+const cmdPending = state(null)
+const cmdTyped = state('')
+const cmdCanRun = derived(() => cmdPending() !== null && cmdTyped().trim() === 'run')
+function askAppCmd() {
   const c = appCmd().trim()
   if (!c) return
+  cmdPending.set(c); cmdTyped.set('')
+}
+function cancelAppCmd() { cmdPending.set(null); cmdTyped.set('') }
+
+async function runAppCmd() {
+  const c = cmdPending()
+  const confirm = cmdTyped().trim()
+  if (!c || confirm !== 'run') return
+  cmdPending.set(null); cmdTyped.set('')
   cmdBusy.set(true); cmdShown.set(true); cmdOut.set('Running ' + c + '...')
   try {
-    const res = await fetch('/api/serverless/command', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ command: c, confirm: 'run' }) })
+    const res = await fetch('/api/serverless/command', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ command: c, confirm }) })
     const b = await res.json()
     cmdOut.set((b.ok ? 'OK ' : 'FAILED ') + (b.command || c) + '\n\n' + (b.stdout || '') + (b.error ? '\n' + b.error : ''))
   } catch (e) { cmdOut.set('FAILED ' + c + '\n\n' + ((e && e.message) || e)) }
@@ -273,8 +290,14 @@ async function runAppCmd() {
       <h2>Run a command</h2>
       <div class="panel">
         <div class="field">
-          <input :value="appCmd()" @input="appCmd.set($event.target.value)" @keydown.enter="runAppCmd()" placeholder="e.g. migrate --force, cache:clear, queue:retry all" autocomplete="off">
-          <button class="btn" type="button" :disabled="cmdBusy()" @click="runAppCmd()">Run</button>
+          <input :value="appCmd()" @input="appCmd.set($event.target.value)" @keydown.enter="askAppCmd()" placeholder="e.g. migrate --force, cache:clear, queue:retry all" autocomplete="off" aria-label="App command to run">
+          <button class="btn" type="button" :disabled="cmdBusy()" @click="askAppCmd()">Run</button>
+        </div>
+        <div class="op-confirm" @show="cmdPending() !== null" style="margin-top:14px">
+          <span>Type <b class="mono">run</b> to execute <b class="mono">{{ cmdPending() }}</b> against production:</span>
+          <input class="op-confirm-input" :value="cmdTyped()" @input="cmdTyped.set($event.target.value)" @keydown.enter="runAppCmd()" placeholder="confirm" autocomplete="off" aria-label="Type run to confirm executing this command">
+          <button type="button" class="btn danger sm" :disabled="!cmdCanRun()" @click="runAppCmd()">Run command</button>
+          <button type="button" class="btn ghost sm" @click="cancelAppCmd()">Cancel</button>
         </div>
         <pre class="action-output" @show="cmdShown()">{{ cmdOut() }}</pre>
         <p class="note">Invokes the app command through the CLI Lambda function (RequestResponse), the same path as <span class="mono">cloud command "..."</span>. Output is clamped.</p>


### PR DESCRIPTION
Closes #123.

Four destructive dashboard actions executed on the first click. All now stage a typed confirmation, using the pattern already established by `firewall`/`secrets`/`alarms`.

### Removals

- **team** — `Remove` fired `DELETE /api/users` immediately, pulling someone's access to every site on the box.
- **ssh-keys** — `Remove` fired `DELETE /api/ssh-keys` immediately. Removing the wrong key can lock every operator out of the box.

Both now require typing the username / key name. Neither endpoint enforces a confirm server-side, so the UI was the only guard and there wasn't one.

### Command runners

This one is worth reading closely. **The API already required a typed confirmation** — `/api/server/command` answers `Type "run" to execute this command on the server.` (`local-dashboard-server.ts:1042`), and `/api/serverless/command` does the same. But the UI never implemented that step and sent `confirm: 'run'` in the body itself, so the gate was satisfied unconditionally and Enter in the box ran arbitrary shell on the production server (or an arbitrary app command — `migrate:fresh`, `queue:flush` — against production).

Note `server/actions.stx` states *"Mutating commands require typed confirmation"* directly above the runner that bypassed it.

The operator now types the word, and the client sends **what they actually typed** rather than asserting the confirmation on their behalf. The confirm bar echoes the exact command so you can see what you're about to run.

The token stays `run` because that's the contract the server enforces today; making it the resource name needs a coordinated server change and is tracked in #124.

### Also

`aria-label`s on the repeated row buttons (they previously announced as a bare "Remove, Remove, Remove") and on the confirm inputs, which only had a placeholder — a small slice of #128 that was free to do here.

### Testing

Lint clean (pickier). Verified no signal-name collisions with the `pending`/`typed`/`canRun` trio these pages already bind to the shared `op-confirm` partial, and that no hardcoded `confirm: 'run'` remains outside a comment. I could not render the pages locally — `packages/ui` pins `@stacksjs/stx@^0.2.73`, which isn't installed in this checkout, and the global `stx` binary is a newer version that rejects `--pages`. Worth a click-through before merge.
