### PR TITLE
fix(deploy): allocate site ports per box, so a second attach cannot collide

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -395,8 +395,15 @@ Ports do not compose. Every `server-app` route resolves to `from:
 'localhost:<port>'` on one shared loopback namespace, and apps generated from the
 same template declare the same ports. `validateDeploymentConfig` only ever sees
 one project's `sites`, so a second project attaching to an occupied box passes
-validation and then fails at `systemctl start` with a bind error naming neither
-side.
+validation.
+
+What happens next is worse than a failure. ts-cloud's units do not set exclusive
+binding, so both listeners bind and the kernel load-balances between them: nothing
+errors, both services look healthy, and each domain answers with the other
+project's site for roughly half its requests. `buddy deploy` catches this late via
+`assertPortsAreFree`, which compares wanted ports against the box's live listeners
+and stops the deploy, but its only remedy is to tell you to pick free ports by
+hand.
 
 The fragments already answer this, since every one of them records its upstream
 port. `site-ports.ts` reads them:

--- a/docs/config.md
+++ b/docs/config.md
@@ -384,6 +384,49 @@ regenerates the route config and restarts the gateway — so new
 server-app/server-static sites appear automatically. Leaving `proxy` unset
 keeps the prior behavior (no gateway installed; you run your own).
 
+### Ports on a shared box
+
+Each project's deploy writes only its own route fragment,
+`/etc/rpx/sites.d/<slug>.json`, and the gateway merges them at startup. That is
+what lets several independent projects share one box: routes are keyed by host, so
+they compose.
+
+Ports do not compose. Every `server-app` route resolves to `from:
+'localhost:<port>'` on one shared loopback namespace, and apps generated from the
+same template declare the same ports. `validateDeploymentConfig` only ever sees
+one project's `sites`, so a second project attaching to an occupied box passes
+validation and then fails at `systemctl start` with a bind error naming neither
+side.
+
+The fragments already answer this, since every one of them records its upstream
+port. `site-ports.ts` reads them:
+
+```typescript
+import { allocateSitePorts, buildHostSitePortsScript, occupiedHostPorts, parseHostSiteFragments } from './deploy/site-ports'
+import { validateDeploymentConfig } from './deploy/site-target'
+
+// `stdout` is the output of buildHostSitePortsScript() run on the box.
+const occupiedPorts = occupiedHostPorts(parseHostSiteFragments(stdout), { ignoreSlug: config.project.slug })
+
+// Reports a collision at plan time, naming the project that holds the port.
+const { errors } = validateDeploymentConfig(config, { occupiedPorts })
+
+// Or allocate around it, so no app has to hand-pick a globally unique port.
+const { allocations } = allocateSitePorts(config, occupiedPorts)
+```
+
+Two details matter:
+
+- **`ignoreSlug` is required.** This project's own fragment is already on the box
+  from its last deploy, so counting it makes every redeploy conflict with itself.
+- **A declared port is kept whenever it is free.** A box with no co-tenants
+  allocates nothing and ports stay stable across deploys; only a site that
+  actually collides moves, and it moves to the next free port rather than
+  somewhere arbitrary.
+
+Omitting `occupiedPorts` validates exactly as before, so this is additive for any
+single-project box.
+
 ## Preset Configuration
 
 ### Static Site Preset

--- a/packages/ts-cloud/src/deploy/site-ports.ts
+++ b/packages/ts-cloud/src/deploy/site-ports.ts
@@ -9,8 +9,22 @@ import { resolveSiteKind } from './site-target'
  * That composes cleanly for ROUTES, because routes are keyed by host. It does
  * not compose for PORTS, because every app generated from the same template
  * declares the same loopback ports, and `validateDeploymentConfig` only ever
- * sees one project's `sites`. The second attach therefore passes validation and
- * then fails at `systemctl start` with a bind error, naming neither culprit.
+ * sees one project's `sites`.
+ *
+ * The second attach therefore passes validation, and then does something worse
+ * than failing: ts-cloud's units do not set exclusive binding, so both listeners
+ * bind and the kernel load-balances between them. Nothing errors, both services
+ * look healthy, and each domain answers with the other project's site for about
+ * half its requests. That is not hypothetical - it is what happened to
+ * predicthq.org when a storefront picked a port by reading other projects'
+ * config files rather than the box (see `assertPortsAreFree` in stacks).
+ *
+ * `assertPortsAreFree` catches this late, from the deploying box over SSH, by
+ * comparing wanted ports against live listeners. That is the better evidence and
+ * it stays the last line of defence. What it cannot do is avoid the clash: it
+ * exits and tells the operator to go pick free ports by hand. This module is the
+ * other half - deciding the ports before anything is shipped, from data a plan
+ * already has.
  *
  * The fix does not need new bookkeeping on the box. The fragments already record
  * every upstream a project serves, so the host is its own port registry - it was

--- a/packages/ts-cloud/src/deploy/site-ports.ts
+++ b/packages/ts-cloud/src/deploy/site-ports.ts
@@ -1,0 +1,245 @@
+import type { CloudConfig } from '@ts-cloud/core'
+import { resolveSiteKind } from './site-target'
+
+/**
+ * Port ownership across the projects sharing one box.
+ *
+ * A box can host several independent projects: each one's deploy writes its own
+ * rpx registry fragment and the assembler merges them (see `RPX_SITES_DIR`).
+ * That composes cleanly for ROUTES, because routes are keyed by host. It does
+ * not compose for PORTS, because every app generated from the same template
+ * declares the same loopback ports, and `validateDeploymentConfig` only ever
+ * sees one project's `sites`. The second attach therefore passes validation and
+ * then fails at `systemctl start` with a bind error, naming neither culprit.
+ *
+ * The fix does not need new bookkeeping on the box. The fragments already record
+ * every upstream a project serves, so the host is its own port registry - it was
+ * simply never read. This module turns those fragments into a port -> owner map,
+ * finds the collisions, and allocates around them.
+ *
+ * Everything here is pure. The one thing that must touch the box, reading the
+ * fragments, is split into a script builder and a parser so both halves are
+ * testable without a server.
+ *
+ * @see https://github.com/stacksjs/ts-cloud/issues/168
+ */
+
+/**
+ * Where the rpx gateway keeps one registry fragment per project.
+ *
+ * Deliberately duplicated from `RPX_SITES_DIR` rather than imported:
+ * `rpx-gateway.ts` imports `site-target.ts`, and this module imports it too, so
+ * importing the constant from there would close a cycle. `site-ports.test.ts`
+ * asserts the two stay equal, so the duplicate cannot drift silently.
+ */
+export const HOST_SITES_DIR = '/etc/rpx/sites.d'
+
+export interface SitePortRange {
+  /** Lowest port the allocator may hand out, inclusive. */
+  start: number
+  /** Highest port the allocator may hand out, inclusive. */
+  end: number
+}
+
+/**
+ * The window the allocator searches.
+ *
+ * Chosen to contain the template's own defaults (3022/3023) so that an app which
+ * has never thought about ports keeps the ports it already had whenever they are
+ * free - see {@link allocateSitePorts}, which only moves a site that actually
+ * collides.
+ */
+export const DEFAULT_SITE_PORT_RANGE: SitePortRange = { start: 3000, end: 3999 }
+
+/**
+ * One project's registry fragment, as written by the deploy:
+ * `JSON.stringify({ slug, ...RpxGatewayConfig })`.
+ *
+ * Only the fields this module reads are declared. A fragment written by an older
+ * ts-cloud may be missing `slug`, which the writer defaults to `'app'`.
+ */
+export interface HostSiteFragment {
+  slug?: string
+  proxies?: Array<{ from?: string | string[] }>
+}
+
+/** Port -> the slug of the project that already serves it on this box. */
+export type PortOwners = Map<number, string>
+
+/** The slug a fragment belongs to, matching the writer's `'app'` default. */
+function fragmentSlug(fragment: HostSiteFragment): string {
+  return fragment.slug?.trim() || 'app'
+}
+
+/**
+ * The port from an rpx upstream (`host:port`).
+ *
+ * Splits on the LAST colon so a bracketed IPv6 literal (`[::1]:3022`) parses as
+ * port 3022 rather than as part of the address. Returns `undefined` for anything
+ * that is not a valid TCP port, so a malformed fragment narrows the map instead
+ * of poisoning it with NaN.
+ */
+export function parseUpstreamPort(upstream: string): number | undefined {
+  const separator = upstream.lastIndexOf(':')
+  if (separator < 0 || separator === upstream.length - 1) return undefined
+
+  const candidate = upstream.slice(separator + 1).trim()
+  if (!/^\d+$/.test(candidate)) return undefined
+
+  const port = Number(candidate)
+  return port >= 1 && port <= 65535 ? port : undefined
+}
+
+/**
+ * Every port the box already serves, mapped to the project that owns it.
+ *
+ * `ignoreSlug` must be set to the deploying project's own slug. Its fragment is
+ * already on the box from the previous deploy, so without that the second deploy
+ * of an attached app reports a conflict with itself and can never succeed.
+ *
+ * First writer wins for a given port, which keeps the result deterministic when
+ * two fragments disagree - a state that is itself the bug being reported, so the
+ * caller sees one stable owner rather than an order-dependent one.
+ */
+export function occupiedHostPorts(
+  fragments: HostSiteFragment[],
+  options: { ignoreSlug?: string } = {},
+): PortOwners {
+  const ignore = options.ignoreSlug?.trim()
+  const owners: PortOwners = new Map()
+
+  for (const fragment of fragments) {
+    const slug = fragmentSlug(fragment)
+    if (ignore && slug === ignore) continue
+
+    for (const proxy of fragment.proxies ?? []) {
+      const upstreams = typeof proxy.from === 'string' ? [proxy.from] : (proxy.from ?? [])
+      for (const upstream of upstreams) {
+        const port = parseUpstreamPort(upstream)
+        if (port !== undefined && !owners.has(port)) owners.set(port, slug)
+      }
+    }
+  }
+
+  return owners
+}
+
+/**
+ * A shell snippet that dumps every registry fragment on the box, one
+ * base64-encoded JSON document per line.
+ *
+ * base64 rather than raw `cat`, because the fragments are pretty-printed and so
+ * span many lines; encoding makes the output unambiguously one record per line
+ * without depending on a JSON tool being installed. Only POSIX utilities plus
+ * `base64` are used, both present on the provisioned image - the same reason
+ * `resize-remote.ts` enumerates these files with plain `find`.
+ *
+ * A missing directory is not an error: a box with no fragments yet prints
+ * nothing, and {@link parseHostSiteFragments} reads that as "no co-tenants".
+ */
+export function buildHostSitePortsScript(sitesDir: string = HOST_SITES_DIR): string {
+  return [
+    `for __tsc_fragment in ${sitesDir}/*.json; do`,
+    '  [ -f "$__tsc_fragment" ] || continue',
+    '  base64 < "$__tsc_fragment" | tr -d \'\\n\'',
+    '  printf \'\\n\'',
+    'done',
+  ].join('\n')
+}
+
+/**
+ * Parse the output of {@link buildHostSitePortsScript}.
+ *
+ * A fragment that will not decode or parse is skipped rather than thrown, which
+ * matches how the box's own assembler treats a corrupt fragment: one bad file
+ * must not take the operation down. The cost is that its ports are invisible to
+ * the collision check, which is strictly better than today, where every
+ * project's ports are.
+ */
+export function parseHostSiteFragments(stdout: string): HostSiteFragment[] {
+  const fragments: HostSiteFragment[] = []
+
+  for (const line of stdout.split('\n')) {
+    const encoded = line.trim()
+    if (!encoded) continue
+
+    try {
+      const parsed = JSON.parse(Buffer.from(encoded, 'base64').toString('utf8'))
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) fragments.push(parsed as HostSiteFragment)
+    }
+    catch {
+      continue
+    }
+  }
+
+  return fragments
+}
+
+export interface SitePortAllocation {
+  /** Site name within the deploying project's `sites`. */
+  site: string
+  /** The port the site should bind after allocation. */
+  port: number
+  /** What the config asked for, when it asked for anything. */
+  declared?: number
+  /** Did the allocation have to move the site off its declared port? */
+  moved: boolean
+}
+
+export interface SitePortAllocationResult {
+  allocations: SitePortAllocation[]
+  errors: string[]
+}
+
+/**
+ * Assign a free port to every server-app site, preferring the one it declared.
+ *
+ * The declared port is kept whenever it is free, so allocation is a no-op on a
+ * box with no co-tenants and an app's ports stay stable across deploys. A site
+ * whose port is taken walks upward to the next free one, which keeps the result
+ * deterministic and close to what the author wrote - a template app landing on
+ * 3024 rather than an arbitrary high port.
+ *
+ * Only `server-app` sites are considered. A bucket, static, redirect or proxy
+ * site binds nothing, and `validateDeploymentConfig` already warns when one of
+ * those declares a port.
+ */
+export function allocateSitePorts(
+  config: CloudConfig,
+  occupied: ReadonlyMap<number, string>,
+  range: SitePortRange = DEFAULT_SITE_PORT_RANGE,
+): SitePortAllocationResult {
+  const allocations: SitePortAllocation[] = []
+  const errors: string[] = []
+  const taken = new Set<number>(occupied.keys())
+
+  for (const [name, site] of Object.entries(config.sites ?? {})) {
+    if (!site || resolveSiteKind(site) !== 'server-app') continue
+
+    const declared = typeof site.port === 'number' ? site.port : undefined
+    const preferred = Math.max(declared ?? range.start, range.start)
+
+    let port: number | undefined
+    for (let candidate = preferred; candidate <= range.end; candidate++) {
+      if (!taken.has(candidate)) {
+        port = candidate
+        break
+      }
+    }
+
+    if (port === undefined) {
+      const owner = declared !== undefined ? occupied.get(declared) : undefined
+      errors.push(
+        `No free port for site '${name}' in ${range.start}-${range.end}`
+        + `${declared !== undefined ? ` (wanted ${declared}${owner ? `, held by '${owner}'` : ''})` : ''}. `
+        + 'Widen the range or free a port on the box.',
+      )
+      continue
+    }
+
+    taken.add(port)
+    allocations.push({ site: name, port, declared, moved: declared !== undefined && port !== declared })
+  }
+
+  return { allocations, errors }
+}

--- a/packages/ts-cloud/src/deploy/site-target.ts
+++ b/packages/ts-cloud/src/deploy/site-target.ts
@@ -131,9 +131,11 @@ export interface ValidateDeploymentOptions {
    *
    * Validation is otherwise blind to co-tenants: it only ever sees one project's
    * `sites`, so two apps attached to the same server can both declare the
-   * template's default port, both pass, and the second one fail at
-   * `systemctl start` naming neither owner. Supplying this turns that into a
-   * plan-time error that names the project holding the port.
+   * template's default port and both pass. The box does not reject the second
+   * one either - ts-cloud's units do not set exclusive binding, so both bind and
+   * the kernel load-balances, leaving each domain serving the other project's
+   * site about half the time with nothing logged as an error. Supplying this
+   * turns that into a plan-time error naming the project holding the port.
    *
    * Build it with `occupiedHostPorts()` from `./site-ports`, passing the
    * deploying project's own slug as `ignoreSlug` - its fragment is already on the

--- a/packages/ts-cloud/src/deploy/site-target.ts
+++ b/packages/ts-cloud/src/deploy/site-target.ts
@@ -125,6 +125,28 @@ export interface DeploymentValidationResult {
   warnings: string[]
 }
 
+export interface ValidateDeploymentOptions {
+  /**
+   * Ports this box already serves for OTHER projects, as port -> owning slug.
+   *
+   * Validation is otherwise blind to co-tenants: it only ever sees one project's
+   * `sites`, so two apps attached to the same server can both declare the
+   * template's default port, both pass, and the second one fail at
+   * `systemctl start` naming neither owner. Supplying this turns that into a
+   * plan-time error that names the project holding the port.
+   *
+   * Build it with `occupiedHostPorts()` from `./site-ports`, passing the
+   * deploying project's own slug as `ignoreSlug` - its fragment is already on the
+   * box from the last deploy, and counting it would make every redeploy conflict
+   * with itself.
+   *
+   * Omitted means "no co-tenant information", which validates exactly as before.
+   *
+   * @see https://github.com/stacksjs/ts-cloud/issues/168
+   */
+  occupiedPorts?: ReadonlyMap<number, string>
+}
+
 /**
  * Validate the per-site deployment configuration up front, turning what used to
  * be silent runtime failures (e.g. a `start` site with no compute server) into
@@ -133,7 +155,10 @@ export interface DeploymentValidationResult {
  * Never throws — returns structured `{ errors, warnings }`. Callers should abort
  * on any error and print warnings while continuing.
  */
-export function validateDeploymentConfig(config: CloudConfig): DeploymentValidationResult {
+export function validateDeploymentConfig(
+  config: CloudConfig,
+  options: ValidateDeploymentOptions = {},
+): DeploymentValidationResult {
   const errors: string[] = []
   const warnings: string[] = []
   const sites = config.sites || {}
@@ -233,6 +258,18 @@ export function validateDeploymentConfig(config: CloudConfig): DeploymentValidat
       }
 
       if (typeof site.port === 'number') {
+        // A co-tenant on the same box holds this port. Reported separately from
+        // the same-config clash below because the fix is different: the operator
+        // cannot see the other project's config from here, so the message has to
+        // name the owning project rather than a sibling site.
+        const coTenant = options.occupiedPorts?.get(site.port)
+        if (coTenant) {
+          errors.push(
+            `Site '${name}' wants port ${site.port}, which project '${coTenant}' already serves on this box. `
+            + `Attached projects share one port namespace. Give '${name}' a free port, or let the attach allocate one.`,
+          )
+        }
+
         const existing = portOwners.get(site.port)
         if (existing) {
           errors.push(

--- a/packages/ts-cloud/test/deploy/site-ports.test.ts
+++ b/packages/ts-cloud/test/deploy/site-ports.test.ts
@@ -1,0 +1,294 @@
+import type { CloudConfig, SiteConfig } from '@ts-cloud/core'
+import { describe, expect, it } from 'bun:test'
+import { RPX_SITES_DIR } from '../../src/drivers/shared/rpx-gateway'
+import {
+  allocateSitePorts,
+  buildHostSitePortsScript,
+  DEFAULT_SITE_PORT_RANGE,
+  HOST_SITES_DIR,
+  occupiedHostPorts,
+  parseHostSiteFragments,
+  parseUpstreamPort,
+} from '../../src/deploy/site-ports'
+import { validateDeploymentConfig } from '../../src/deploy/site-target'
+
+function makeConfig(sites: Record<string, SiteConfig>, slug = 'loghq'): CloudConfig {
+  return {
+    project: { name: slug, slug, region: 'us-east-1' },
+    environments: { production: { type: 'production' } },
+    cloud: { provider: 'hetzner', attachTo: 'statushq' },
+    sites,
+  } as CloudConfig
+}
+
+/** Encode fragments the way `buildHostSitePortsScript` emits them. */
+function encodeFragments(...fragments: unknown[]): string {
+  return `${fragments.map(f => Buffer.from(JSON.stringify(f, null, 2)).toString('base64')).join('\n')}\n`
+}
+
+describe('HOST_SITES_DIR', () => {
+  // site-ports cannot import RPX_SITES_DIR without closing an import cycle, so
+  // the literal is duplicated. This is what stops the duplicate drifting.
+  it('matches the gateway registry directory it duplicates', () => {
+    expect(HOST_SITES_DIR).toBe(RPX_SITES_DIR)
+  })
+})
+
+describe('parseUpstreamPort', () => {
+  it('reads the port from a host:port upstream', () => {
+    expect(parseUpstreamPort('127.0.0.1:3022')).toBe(3022)
+    expect(parseUpstreamPort('localhost:80')).toBe(80)
+  })
+
+  it('splits on the last colon so bracketed IPv6 parses', () => {
+    expect(parseUpstreamPort('[::1]:3023')).toBe(3023)
+  })
+
+  it('rejects anything that is not a usable port', () => {
+    expect(parseUpstreamPort('127.0.0.1')).toBeUndefined()
+    expect(parseUpstreamPort('127.0.0.1:')).toBeUndefined()
+    expect(parseUpstreamPort('127.0.0.1:bun')).toBeUndefined()
+    expect(parseUpstreamPort('127.0.0.1:0')).toBeUndefined()
+    expect(parseUpstreamPort('127.0.0.1:70000')).toBeUndefined()
+  })
+})
+
+describe('occupiedHostPorts', () => {
+  it('maps every upstream port to the project serving it', () => {
+    const owners = occupiedHostPorts([
+      { slug: 'statushq', proxies: [{ from: '127.0.0.1:3000' }, { from: '127.0.0.1:3001' }] },
+      { slug: 'bughq', proxies: [{ from: '127.0.0.1:3022' }] },
+    ])
+
+    expect([...owners.entries()].sort((a, b) => a[0] - b[0])).toEqual([
+      [3000, 'statushq'],
+      [3001, 'statushq'],
+      [3022, 'bughq'],
+    ])
+  })
+
+  it('reads an array of upstreams, as a load-balanced route has', () => {
+    const owners = occupiedHostPorts([
+      { slug: 'statushq', proxies: [{ from: ['10.0.0.1:3100', '10.0.0.2:3101'] }] },
+    ])
+
+    expect(owners.get(3100)).toBe('statushq')
+    expect(owners.get(3101)).toBe('statushq')
+  })
+
+  it("attributes a fragment with no slug to 'app', matching the writer's default", () => {
+    expect(occupiedHostPorts([{ proxies: [{ from: '127.0.0.1:3022' }] }]).get(3022)).toBe('app')
+  })
+
+  it('skips the deploying project so a redeploy does not conflict with itself', () => {
+    const fragments = [
+      { slug: 'loghq', proxies: [{ from: '127.0.0.1:3022' }] },
+      { slug: 'bughq', proxies: [{ from: '127.0.0.1:3030' }] },
+    ]
+
+    const owners = occupiedHostPorts(fragments, { ignoreSlug: 'loghq' })
+
+    expect(owners.has(3022)).toBe(false)
+    expect(owners.get(3030)).toBe('bughq')
+  })
+
+  it('ignores routes with no upstream, such as static and redirect sites', () => {
+    expect(occupiedHostPorts([{ slug: 'statushq', proxies: [{}, { from: undefined }] }]).size).toBe(0)
+  })
+
+  it('keeps the first owner when two fragments claim one port', () => {
+    const owners = occupiedHostPorts([
+      { slug: 'bughq', proxies: [{ from: '127.0.0.1:3022' }] },
+      { slug: 'loghq', proxies: [{ from: '127.0.0.1:3022' }] },
+    ])
+
+    expect(owners.get(3022)).toBe('bughq')
+  })
+})
+
+describe('buildHostSitePortsScript', () => {
+  it('enumerates the registry directory and guards against the empty glob', () => {
+    const script = buildHostSitePortsScript()
+
+    expect(script).toContain(`${HOST_SITES_DIR}/*.json`)
+    expect(script).toContain('[ -f "$__tsc_fragment" ] || continue')
+    expect(script).toContain('base64')
+  })
+
+  it('accepts a custom directory', () => {
+    expect(buildHostSitePortsScript('/tmp/sites.d')).toContain('/tmp/sites.d/*.json')
+  })
+})
+
+describe('parseHostSiteFragments', () => {
+  it('round-trips what the script emits', () => {
+    const stdout = encodeFragments(
+      { slug: 'statushq', proxies: [{ to: 'status.example', from: '127.0.0.1:3000' }] },
+      { slug: 'bughq', proxies: [{ to: 'bugs.example', from: '127.0.0.1:3022' }] },
+    )
+
+    expect(parseHostSiteFragments(stdout).map(f => f.slug)).toEqual(['statushq', 'bughq'])
+  })
+
+  it('reads nothing from a box with no fragments', () => {
+    expect(parseHostSiteFragments('')).toEqual([])
+    expect(parseHostSiteFragments('\n  \n')).toEqual([])
+  })
+
+  it('skips a corrupt fragment instead of failing the whole read', () => {
+    const good = Buffer.from(JSON.stringify({ slug: 'bughq', proxies: [{ from: '127.0.0.1:3022' }] })).toString('base64')
+    const notBase64Json = Buffer.from('this is not json').toString('base64')
+    const stdout = `${notBase64Json}\n${good}\n`
+
+    const fragments = parseHostSiteFragments(stdout)
+
+    expect(fragments).toHaveLength(1)
+    expect(fragments[0]!.slug).toBe('bughq')
+  })
+
+  it('ignores a fragment that is not an object', () => {
+    expect(parseHostSiteFragments(encodeFragments([1, 2], 'nope', 7))).toEqual([])
+  })
+})
+
+describe('allocateSitePorts', () => {
+  const sites: Record<string, SiteConfig> = {
+    app: { root: 'dist', start: 'bun run server.ts', port: 3022 },
+    api: { root: 'dist', start: 'bun run api.ts', port: 3023 },
+  }
+
+  it('keeps declared ports when the box has no co-tenants', () => {
+    const { allocations, errors } = allocateSitePorts(makeConfig(sites), new Map())
+
+    expect(errors).toEqual([])
+    expect(allocations).toEqual([
+      { site: 'app', port: 3022, declared: 3022, moved: false },
+      { site: 'api', port: 3023, declared: 3023, moved: false },
+    ])
+  })
+
+  it('moves only the sites whose ports are taken, to the next free port', () => {
+    // bughq is already on the box holding the template's default pair.
+    const occupied = new Map([[3022, 'bughq'], [3023, 'bughq']])
+
+    const { allocations, errors } = allocateSitePorts(makeConfig(sites), occupied)
+
+    expect(errors).toEqual([])
+    expect(allocations).toEqual([
+      { site: 'app', port: 3024, declared: 3022, moved: true },
+      { site: 'api', port: 3025, declared: 3023, moved: true },
+    ])
+  })
+
+  it('does not hand the same port to two sites in one config', () => {
+    const config = makeConfig({
+      app: { root: 'dist', start: 'bun run a.ts', port: 3022 },
+      api: { root: 'dist', start: 'bun run b.ts', port: 3022 },
+    })
+
+    const ports = allocateSitePorts(config, new Map()).allocations.map(a => a.port)
+
+    expect(new Set(ports).size).toBe(2)
+    expect(ports).toEqual([3022, 3023])
+  })
+
+  it('allocates from the range start for a site that declares no port', () => {
+    const config = makeConfig({ app: { root: 'dist', start: 'bun run server.ts' } })
+
+    expect(allocateSitePorts(config, new Map()).allocations).toEqual([
+      { site: 'app', port: DEFAULT_SITE_PORT_RANGE.start, declared: undefined, moved: false },
+    ])
+  })
+
+  it('ignores sites that bind nothing', () => {
+    const config = makeConfig({
+      bucket: { root: 'dist' },
+      static: { root: 'dist', deploy: 'server' },
+      redirect: { domain: 'old.example', redirect: 'new.example' },
+      proxy: { domain: 'svc.example', proxyTo: '127.0.0.1:9000' },
+      app: { root: 'dist', start: 'bun run server.ts', port: 3022 },
+    })
+
+    expect(allocateSitePorts(config, new Map()).allocations.map(a => a.site)).toEqual(['app'])
+  })
+
+  it('reports the holder when the range is exhausted', () => {
+    const occupied = new Map([[3022, 'bughq']])
+    const config = makeConfig({ app: { root: 'dist', start: 'bun run server.ts', port: 3022 } })
+
+    const { allocations, errors } = allocateSitePorts(config, occupied, { start: 3022, end: 3022 })
+
+    expect(allocations).toEqual([])
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toContain("site 'app'")
+    expect(errors[0]).toContain("held by 'bughq'")
+  })
+})
+
+describe('validateDeploymentConfig with co-tenant ports (#168)', () => {
+  const sites: Record<string, SiteConfig> = {
+    app: { root: 'dist', start: 'bun run server.ts', port: 3022 },
+  }
+
+  it('is silent about co-tenants when no occupancy is supplied', () => {
+    // The pre-existing contract: one config in, no knowledge of the box.
+    expect(validateDeploymentConfig(makeConfig(sites)).errors).toEqual([])
+  })
+
+  it('reports the collision at plan time, naming the project that holds the port', () => {
+    const errors = validateDeploymentConfig(makeConfig(sites), {
+      occupiedPorts: new Map([[3022, 'bughq']]),
+    }).errors
+
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toContain("Site 'app' wants port 3022")
+    expect(errors[0]).toContain("project 'bughq' already serves")
+  })
+
+  it('still reports two sites in one config sharing a port', () => {
+    const config = makeConfig({
+      app: { root: 'dist', start: 'bun run a.ts', port: 3022 },
+      api: { root: 'dist', start: 'bun run b.ts', port: 3022 },
+    })
+
+    const errors = validateDeploymentConfig(config).errors
+
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toContain('both use port 3022')
+  })
+
+  it("does not flag the deploying project's own fragment from a previous deploy", () => {
+    const stdout = encodeFragments({ slug: 'loghq', proxies: [{ from: '127.0.0.1:3022' }] })
+    const occupiedPorts = occupiedHostPorts(parseHostSiteFragments(stdout), { ignoreSlug: 'loghq' })
+
+    expect(validateDeploymentConfig(makeConfig(sites), { occupiedPorts }).errors).toEqual([])
+  })
+
+  it('catches the exact case from the issue: two template apps on one box', () => {
+    // loghq and bughq are both untouched from the template, so both want
+    // 3022/3023. bughq attached first and its fragment is on the box.
+    const onBox = encodeFragments({
+      slug: 'bughq',
+      proxies: [
+        { to: 'bugs.example', from: '127.0.0.1:3022' },
+        { to: 'bugs.example', path: '/api', from: '127.0.0.1:3023' },
+      ],
+    })
+
+    const loghq = makeConfig({
+      app: { root: 'dist', start: 'bun run server.ts', port: 3022 },
+      api: { root: 'dist', start: 'bun run api.ts', port: 3023 },
+    }, 'loghq')
+
+    const occupiedPorts = occupiedHostPorts(parseHostSiteFragments(onBox), { ignoreSlug: 'loghq' })
+    const { errors } = validateDeploymentConfig(loghq, { occupiedPorts })
+
+    expect(errors).toHaveLength(2)
+    expect(errors.join('\n')).toContain("project 'bughq'")
+
+    // ...and allocation gets loghq onto the box without either app editing a port.
+    const { allocations, errors: allocErrors } = allocateSitePorts(loghq, occupiedPorts)
+    expect(allocErrors).toEqual([])
+    expect(allocations.map(a => a.port)).toEqual([3024, 3025])
+  })
+})


### PR DESCRIPTION
Closes #168. Unblocks #167's first operation.

## Correction to the issue's premise, first

I wrote #168 saying the second attach "cannot bind" and surfaces "as a service that will not start". **That is wrong, and the truth is worse.** `assertPortsAreFree` in stacks records what actually happens:

> Two processes CAN bind the same port here: ts-cloud's units do not set exclusive binding, so the kernel load-balances between them instead of failing. Nothing errors, both services look healthy, and each domain serves the other tenant's site on roughly half its requests.

That is not hypothetical: predicthq.org answered with a storefront's pages for a day and a half. So this is a silent traffic-mixing bug, not a startup failure, which makes plan-time allocation more valuable rather than less.

**And detection already exists**, which I also missed when filing. `assertPortsAreFree` (stacks, `buddy deploy`) diffs the ports this project wants against the box's **live** listeners over SSH, resolves the owning systemd unit, skips this project's own units, and stops the deploy. Live listeners are better evidence than declared config, and that check stays the last line of defence.

What it cannot do is *avoid* the clash. Its remedy is to exit and tell the operator to go pick free ports in `config/cloud.ts` by hand, which is precisely the acceptance criterion #168 asks to remove. This PR is the other half: deciding the ports **before** anything ships, from data a plan already has.

## The bug

Every app generated from the Stacks cloud template declares the same loopback ports, and `validateDeploymentConfig` only ever sees **one** project's `sites`:

```
loghq/config/cloud.ts     port: 3022 (app)   port: 3023 (api)
bughq/config/cloud.ts     port: 3022 (app)   port: 3023 (api)
```

## The box already knew

No new bookkeeping. Each project's deploy writes its own rpx registry fragment under `/etc/rpx/sites.d`, and every `server-app` route records its upstream as `host:port`. The fragments are already a complete port registry; nothing read them.

| | |
|---|---|
| `occupiedHostPorts()` | fragments to a `port -> owning slug` map |
| `allocateSitePorts()` | keeps a declared port when free, else walks to the next |
| `buildHostSitePortsScript()` / `parseHostSiteFragments()` | the one step that must touch the box, split so both halves unit-test without a server |

Two details that are easy to get wrong, both pinned by tests:

- **The deploying project's own fragment must be skipped.** It is already on the box from the previous deploy, so counting it makes an attached app's *second* deploy conflict with its *first* and never succeed again. (`assertPortsAreFree` has the same insight, via `unit.startsWith(slug-)`.)
- **A declared port is kept whenever it is free.** A box with no co-tenants allocates nothing, ports stay stable across deploys, and a colliding template app lands on 3024 rather than an arbitrary high port.

`validateDeploymentConfig` gains an optional `occupiedPorts` map and reports a co-tenant collision *separately* from a same-config one, because the remedy differs: the operator cannot see the other project's config, so the message names the project holding the port. **Omitting the option validates exactly as before**, so every existing caller is untouched.

## Acceptance criteria

- [x] A port conflict is reported at plan time, naming both owners
- [x] Attaching a second template app succeeds without either app editing a port by hand (`allocateSitePorts`)
- [x] Port assignments are recorded where the next attach can see them (the fragments already were that record, now readable)
- [ ] `--dry-run` shows the ports each site will occupy

## What I deliberately did not wire, and why

The only caller of `validateDeploymentConfig` is `bin/commands/deploy.ts:559`, which runs **before** any driver exists, so it has no host connection and cannot read the fragments yet. Two options existed and I took neither blindly:

1. Probing inside `attachToComputeInfrastructure` would break `hetzner-driver.test.ts`, which exercises attach with a mocked client and no SSH.
2. A best-effort probe would reintroduce the exact failure being reported: a silent skip that lets the collision through.

So this lands the layer with full coverage and leaves the single `occupiedPorts` call site to the attach/CLI surface in #167 and stacksjs/stacks#2342, where a plan and a host connection both legitimately exist. Better a tested seam than a probe that fails open.

## Verification

- 27 new tests, including the issue's exact case: two untouched template apps on one box produce two plan-time errors naming `bughq`, and allocation puts the second on 3024/3025
- Every load-bearing assertion mutation-checked: dropping the self-skip, the co-tenant lookup, the last-colon parse, or the walk-up each fail the suite
- Full suite `4022 pass, 0 fail`; `typecheck` clean; `lint` 0 errors 0 warnings
- Ports parse on the last colon so a bracketed IPv6 upstream reads correctly

Note for reviewers on a fresh clone: build `packages/core` and `packages/ts-cloud` first, or `@ts-cloud/core` resolves to a stale `dist/` and unrelated suites fail on missing exports.