### PR TITLE
docs(cloud): say what attaching does to a credential's blast radius

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -105,6 +105,54 @@ Every field is optional, and each resolves through the same chain:
 
 `infrastructure.compute.image` overrides `hetzner.image` when set: it is the provider-agnostic way to pin an image, and it is what a golden-image bake sets.
 
+## Attaching to another project's server
+
+Set `cloud.attachTo` to an owner project's `project.slug` to deploy this project's
+sites onto a box that project already runs, instead of provisioning one:
+
+```typescript
+export default {
+  project: { name: 'LogHQ', slug: 'loghq', region: 'us-east-1' },
+  cloud: { provider: 'hetzner', attachTo: 'statushq' },
+  sites: { app: { root: 'dist', start: 'bun run server.ts', port: 3022 } },
+} satisfies Partial<CloudConfig>
+```
+
+The deploy targets the owner's `<slug>-<environment>-app` server, ships only this
+project's sites, and adds its own additive rpx `sites.d/<slug>.json` fragment plus
+DNS. It never touches the owner's box lifecycle, firewall, or other tenants: the
+owner provisions and manages the shared box, attachers only deploy onto it.
+
+### It widens what your CI credential can reach
+
+Attaching finds the owner's box by **listing** the provider's servers with this
+project's own token. That is the whole mechanism, and it has a consequence worth
+stating plainly before you adopt it: the owner's box must be visible to the
+attacher's credential, so both projects have to live in the same provider project.
+
+On Hetzner there is no narrower option. A Cloud API token is scoped to a project
+with Read or Read & Write, with no per-resource scoping, and a deploy needs write.
+So once `attachTo` is set, this project's CI token can modify and delete every
+server in that provider project:
+
+| Before | After |
+|---|---|
+| `loghq` CI reaches the `loghq` box | `loghq` CI reaches `statushq`, `bughq`, `stacks`, `localtunnels` |
+| `bughq` CI reaches the `bughq` box | `bughq` CI reaches all of the above |
+
+Three pipelines that each had blast radius over one box now each have it over the
+whole fleet. A compromised CI run or a mistargeted teardown reaches production
+systems belonging to unrelated apps.
+
+**Per-project isolation and attaching are mutually exclusive.** An app kept in its
+own provider project cannot be attached at all, because its token cannot see the
+owner's box. Co-hosting trades credential isolation for a shared box; that trade
+is often worth making, but it should be a decision rather than a surprise.
+
+`describeCredentialReach()` and `formatCredentialReach()` report what a given
+token actually reaches, separating the owner's boxes from the ones no one asked
+for, so the radius can be shown before an attach is approved.
+
 ## Two app models
 
 ts-cloud deploys apps two ways; pick per environment:

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -15,7 +15,34 @@ export interface CloudProviderConfig {
    * this project's sites, and adds its own additive rpx `sites.d/<slug>.json`
    * fragment + DNS — never touching the owner's box lifecycle, firewall, or other
    * tenants. The owner provisions and manages the shared box; attachers only
-   * deploy onto it. Requires read access via the same `HCLOUD_TOKEN`.
+   * deploy onto it.
+   *
+   * ## This widens what your CI credential can reach
+   *
+   * Attaching resolves the host by listing the provider's servers with THIS
+   * project's own token, so the owner's box has to be visible to it, which means
+   * both projects live in the same provider project. On Hetzner that is the whole
+   * story: Cloud API tokens are scoped to a project with Read or Read & Write and
+   * offer no per-resource scoping, and a deploy needs write. So the moment this is
+   * set, this project's CI token can modify and delete EVERY server in that
+   * provider project, not just the box it deploys to.
+   *
+   * Concretely, three apps that each owned one box become three pipelines that
+   * each reach all three, plus anything else in the project. That is a real change
+   * in blast radius: a compromised CI run or a mistargeted teardown now reaches
+   * production systems belonging to unrelated apps.
+   *
+   * **Per-project isolation and attaching are mutually exclusive.** An app kept in
+   * its own provider project cannot be attached at all, because its token cannot
+   * see the owner's box. Choosing to co-host is choosing to trade credential
+   * isolation for a shared box; the reverse trade is equally available, and neither
+   * is a default worth stumbling into.
+   *
+   * `describeCredentialReach()` reports what a given token can actually reach, so
+   * the radius can be shown before an attach is approved rather than discovered
+   * afterwards.
+   *
+   * @see https://github.com/stacksjs/ts-cloud/issues/169
    */
   attachTo?: string
 }

--- a/packages/ts-cloud/src/deploy/attach-credentials.ts
+++ b/packages/ts-cloud/src/deploy/attach-credentials.ts
@@ -1,0 +1,149 @@
+import { TS_CLOUD_LABEL_PREFIX } from '../drivers/hetzner/instance-sizes'
+
+/**
+ * What a provider credential can actually reach, so an attach can say so before
+ * it is approved.
+ *
+ * Attaching resolves the owner's box by LISTING the provider's servers with the
+ * attaching project's own token. That listing is the whole mechanism, and it has
+ * a consequence the config never states: the owner's box must be visible to the
+ * attacher's credential, so both projects share one provider project. On Hetzner
+ * a Cloud API token is scoped to a project with Read or Read & Write and has no
+ * per-resource scoping, and a deploy needs write. Attaching therefore hands this
+ * project's CI write access over every server in that project.
+ *
+ * That is not a hypothetical. Three apps that each owned one box become three
+ * pipelines that each reach all three. The trade may well be worth it, but it
+ * should be a decision rather than a discovery, and the only honest place to
+ * surface it is the plan, where the operator is already looking.
+ *
+ * Pure and provider-agnostic on purpose: it reads a list of names and labels, so
+ * any driver that can enumerate what its credential sees can report a radius,
+ * rather than the reporting being welded to one provider's client.
+ *
+ * @see https://github.com/stacksjs/ts-cloud/issues/169
+ */
+
+/** The label carrying a resource's owning project slug. */
+const PROJECT_LABEL = `${TS_CLOUD_LABEL_PREFIX}/project`
+
+/**
+ * The minimum a driver has to produce for a server to be attributed.
+ *
+ * Structural rather than a provider type so a Hetzner server satisfies it as-is
+ * and another driver can satisfy it without importing anything.
+ */
+export interface ReachableServer {
+  name: string
+  labels?: Record<string, string>
+}
+
+export interface CredentialReach {
+  /** Every server the credential enumerated. */
+  total: number
+  /** Servers belonging to the project being attached TO. Expected reach. */
+  owner: string[]
+  /** Servers belonging to the attaching project itself, if it has any. */
+  self: string[]
+  /** Servers owned by unrelated ts-cloud projects, keyed by project slug. */
+  others: Map<string, string[]>
+  /**
+   * Servers carrying no ts-cloud project label.
+   *
+   * Counted separately because they are the reach most likely to surprise: not
+   * managed by ts-cloud at all, and so not visible in any ts-cloud config, yet
+   * just as writable by the token.
+   */
+  unmanaged: string[]
+}
+
+/**
+ * Attribute every server the credential can see to a project.
+ *
+ * `ownerSlug` is what `cloud.attachTo` names; `selfSlug` is the deploying
+ * project. Splitting those two out of `others` is the point: reach over the owner
+ * is the reach being asked for, reach over anything else is the reach nobody
+ * asked for, and only the second number is an argument against attaching.
+ */
+export function describeCredentialReach(
+  servers: ReachableServer[],
+  options: { ownerSlug: string, selfSlug?: string },
+): CredentialReach {
+  const ownerSlug = options.ownerSlug.trim()
+  const selfSlug = options.selfSlug?.trim()
+
+  const reach: CredentialReach = { total: servers.length, owner: [], self: [], others: new Map(), unmanaged: [] }
+
+  for (const server of servers) {
+    const project = server.labels?.[PROJECT_LABEL]?.trim()
+
+    if (!project) {
+      reach.unmanaged.push(server.name)
+      continue
+    }
+    if (project === ownerSlug) {
+      reach.owner.push(server.name)
+      continue
+    }
+    if (selfSlug && project === selfSlug) {
+      reach.self.push(server.name)
+      continue
+    }
+
+    const existing = reach.others.get(project)
+    if (existing) existing.push(server.name)
+    else reach.others.set(project, [server.name])
+  }
+
+  return reach
+}
+
+/** Servers the credential reaches that neither project being joined owns. */
+export function unrelatedReachCount(reach: CredentialReach): number {
+  let count = reach.unmanaged.length
+  for (const names of reach.others.values()) count += names.length
+  return count
+}
+
+/**
+ * The credential radius as plan lines, ready to print.
+ *
+ * Returns lines rather than printing so the caller owns the output stream and
+ * this stays testable. Sorted, because a plan that reorders itself between runs
+ * is a plan nobody diffs.
+ *
+ * When the reach is exactly the owner's box and this project's own, there is
+ * nothing to warn about and the summary says so in one line - a warning that
+ * fires every time is a warning that gets skipped.
+ */
+export function formatCredentialReach(
+  reach: CredentialReach,
+  options: { ownerSlug: string, selfSlug?: string },
+): string[] {
+  const unrelated = unrelatedReachCount(reach)
+  const lines: string[] = []
+
+  lines.push(
+    `Attaching to '${options.ownerSlug}' shares one provider project, so this deploy's credential can write to all ${reach.total} server(s) it can see.`,
+  )
+
+  if (unrelated === 0) {
+    lines.push('Nothing outside the two projects being joined is reachable with it.')
+    return lines
+  }
+
+  lines.push(`${unrelated} of them belong to neither project:`)
+
+  for (const project of [...reach.others.keys()].sort())
+    lines.push(`  ${project}: ${[...reach.others.get(project)!].sort().join(', ')}`)
+
+  if (reach.unmanaged.length > 0)
+    lines.push(`  not managed by ts-cloud: ${[...reach.unmanaged].sort().join(', ')}`)
+
+  lines.push(
+    'A compromised CI run or a mistargeted teardown in this project now reaches those. '
+    + 'Keep the app in its own provider project instead if that is not acceptable, which rules out attaching.',
+  )
+
+  return lines
+}

--- a/packages/ts-cloud/test/deploy/attach-credentials.test.ts
+++ b/packages/ts-cloud/test/deploy/attach-credentials.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  describeCredentialReach,
+  formatCredentialReach,
+  unrelatedReachCount,
+} from '../../src/deploy/attach-credentials'
+import { TS_CLOUD_LABEL_PREFIX } from '../../src/drivers/hetzner/instance-sizes'
+
+const PROJECT_LABEL = `${TS_CLOUD_LABEL_PREFIX}/project`
+
+/** A server as a driver's `listServers()` returns it, labelled or not. */
+function server(name: string, project?: string) {
+  return project === undefined ? { name } : { name, labels: { [PROJECT_LABEL]: project } }
+}
+
+/** The fleet from the issue: one Hetzner project, five boxes. */
+const fleet = [
+  server('statushq-production-app', 'statushq'),
+  server('bughq-production-app', 'bughq'),
+  server('loghq-production-app', 'loghq'),
+  server('stacks-production-app', 'stacks'),
+  server('localtunnels-production-app', 'localtunnels'),
+]
+
+describe('describeCredentialReach', () => {
+  it('separates the owner, this project, unrelated projects and unmanaged boxes', () => {
+    const reach = describeCredentialReach(
+      [...fleet, server('someones-database')],
+      { ownerSlug: 'statushq', selfSlug: 'loghq' },
+    )
+
+    expect(reach.total).toBe(6)
+    expect(reach.owner).toEqual(['statushq-production-app'])
+    expect(reach.self).toEqual(['loghq-production-app'])
+    expect([...reach.others.keys()].sort()).toEqual(['bughq', 'localtunnels', 'stacks'])
+    expect(reach.unmanaged).toEqual(['someones-database'])
+  })
+
+  it('groups several servers under one project', () => {
+    const reach = describeCredentialReach(
+      [server('bughq-production-app', 'bughq'), server('bughq-production-lb', 'bughq')],
+      { ownerSlug: 'statushq', selfSlug: 'loghq' },
+    )
+
+    expect(reach.others.get('bughq')).toEqual(['bughq-production-app', 'bughq-production-lb'])
+  })
+
+  it("treats this project's own boxes as unrelated when no selfSlug is given", () => {
+    const reach = describeCredentialReach([server('loghq-production-app', 'loghq')], { ownerSlug: 'statushq' })
+
+    expect(reach.self).toEqual([])
+    expect(reach.others.get('loghq')).toEqual(['loghq-production-app'])
+  })
+
+  it('counts a blank project label as unmanaged rather than as a project named ""', () => {
+    const reach = describeCredentialReach(
+      [{ name: 'odd-box', labels: { [PROJECT_LABEL]: '   ' } }],
+      { ownerSlug: 'statushq' },
+    )
+
+    expect(reach.unmanaged).toEqual(['odd-box'])
+    expect(reach.others.size).toBe(0)
+  })
+
+  it('reports nothing reachable for an empty listing', () => {
+    const reach = describeCredentialReach([], { ownerSlug: 'statushq', selfSlug: 'loghq' })
+
+    expect(reach.total).toBe(0)
+    expect(unrelatedReachCount(reach)).toBe(0)
+  })
+})
+
+describe('unrelatedReachCount', () => {
+  it('counts every server neither joined project owns', () => {
+    const reach = describeCredentialReach([...fleet, server('someones-database')], {
+      ownerSlug: 'statushq',
+      selfSlug: 'loghq',
+    })
+
+    // bughq + stacks + localtunnels + the unlabelled box.
+    expect(unrelatedReachCount(reach)).toBe(4)
+  })
+})
+
+describe('formatCredentialReach', () => {
+  it('says so in one line when only the two joined projects are reachable', () => {
+    const reach = describeCredentialReach(
+      [server('statushq-production-app', 'statushq'), server('loghq-production-app', 'loghq')],
+      { ownerSlug: 'statushq', selfSlug: 'loghq' },
+    )
+
+    const lines = formatCredentialReach(reach, { ownerSlug: 'statushq', selfSlug: 'loghq' })
+
+    expect(lines).toHaveLength(2)
+    expect(lines[1]).toContain('Nothing outside the two projects')
+  })
+
+  it('names every unrelated project and box, sorted so the plan is diffable', () => {
+    const reach = describeCredentialReach([...fleet, server('someones-database')], {
+      ownerSlug: 'statushq',
+      selfSlug: 'loghq',
+    })
+
+    const lines = formatCredentialReach(reach, { ownerSlug: 'statushq', selfSlug: 'loghq' })
+    const body = lines.join('\n')
+
+    expect(lines[0]).toContain('all 6 server(s)')
+    expect(body).toContain('4 of them belong to neither project')
+    expect(body).toContain('bughq: bughq-production-app')
+    expect(body).toContain('localtunnels: localtunnels-production-app')
+    expect(body).toContain('stacks: stacks-production-app')
+    expect(body).toContain('not managed by ts-cloud: someones-database')
+
+    // The unrelated projects appear in sorted order.
+    expect(body.indexOf('bughq:')).toBeLessThan(body.indexOf('localtunnels:'))
+    expect(body.indexOf('localtunnels:')).toBeLessThan(body.indexOf('stacks:'))
+  })
+
+  it('states the isolation tradeoff, since that is the decision being made', () => {
+    const reach = describeCredentialReach(fleet, { ownerSlug: 'statushq', selfSlug: 'loghq' })
+
+    expect(formatCredentialReach(reach, { ownerSlug: 'statushq', selfSlug: 'loghq' }).join('\n'))
+      .toContain('own provider project')
+  })
+
+  it('is stable across runs for the same input', () => {
+    const reach = describeCredentialReach([...fleet].reverse(), { ownerSlug: 'statushq', selfSlug: 'loghq' })
+    const a = formatCredentialReach(reach, { ownerSlug: 'statushq', selfSlug: 'loghq' })
+    const b = formatCredentialReach(reach, { ownerSlug: 'statushq', selfSlug: 'loghq' })
+
+    expect(a).toEqual(b)
+  })
+})


### PR DESCRIPTION
Addresses #169 (three of its four acceptance criteria; the fourth is called out below).

## What was wrong

`cloud.attachTo` finds the owner's box by **listing** the provider's servers with the attaching project's own token. That listing is the whole mechanism, and it forces something the config never said: the owner's box must be visible to the attacher's credential, so both projects have to share one provider project. On Hetzner a Cloud API token is project-scoped with Read or Read & Write, has no per-resource scoping, and a deploy needs write.

The old docstring said *"Requires read access via the same `HCLOUD_TOKEN`"*, which understates it twice: the access needed is **write**, and the reach is the **whole provider project**, not the one box.

| Before | After |
|---|---|
| `loghq` CI reaches the `loghq` box | `loghq` CI reaches `statushq`, `bughq`, `stacks`, `localtunnels` |
| `bughq` CI reaches the `bughq` box | `bughq` CI reaches all of the above |

And the other half of the same decision, now stated: **per-project isolation and attaching are mutually exclusive.** An app kept in its own provider project cannot be attached at all, because its token cannot see the owner's box.

## What this adds

- The `attachTo` docstring now states the radius, the write requirement, and the mutual exclusivity.
- A new `docs/config.md` section, "Attaching to another project's server", since `attachTo` appeared nowhere in `docs/` at all.
- `describeCredentialReach()` attributes every server a credential can enumerate to a project, keeping the owner's boxes and this project's own **separate** from the ones nobody asked to reach. Only that last number is an argument against attaching, so collapsing them would bury the point.
- `formatCredentialReach()` renders sorted, run-to-run stable plan lines, and stays quiet with one summary line when the reach really is just the two projects being joined. A warning that fires every time is a warning that gets skipped.

Both are pure and structurally typed over `{ name, labels }` rather than a Hetzner server, so any driver that can enumerate what its credential sees can report a radius.

## Acceptance criteria

- [x] `attachTo` documents that it requires the same provider project and what that grants
- [x] The docs state plainly that per-project isolation and attaching are mutually exclusive
- [x] The attach plan *can* report the other resources the credential reaches (the reporting exists and is tested; the print call belongs to the attach plan surface in #167 / stacksjs/stacks#2342, which is where a plan is actually rendered)
- [ ] The driver interface allows a narrower credential where a provider supports one

## On that last box

I did not change the `CloudDriver` interface. Hetzner cannot express a narrower credential at all, so the only honest way to design that seam is against a provider that can (AWS IAM), and guessing the shape from the provider that cannot is how you get an abstraction that fits nobody. Making the reporting provider-agnostic is the part that is useful today and does not need that guess; I would rather leave the interface change to whoever does it against a real second credential model.

## Verification

- 10 new tests, including the issue's own five-box fleet: attaching `loghq` to `statushq` reports 4 servers reachable that neither project owns
- Full suite `4005 pass, 0 fail`; `typecheck` clean; `lint` 0 errors 0 warnings

Related: #168 / #170 covers the port collision on the same shared box.