### PR TITLE
fix(deploy): keep SQLite across deploys, and preflight an attached host's services

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -344,6 +344,54 @@ clean. If a site targets a server (`deploy: 'server'`, or `start` set) but no
 actionable error instead of failing silently at runtime — set `deploy: 'bucket'`
 or add a server.
 
+### State that must survive a deploy
+
+Each deploy unpacks into a NEW `releases/<id>` directory and flips `current` at
+it; old releases are pruned. Anything the app writes and must keep therefore has
+to live in the site's `shared/` directory and be symlinked in, which is what
+`site.sharedPaths` declares. `.env` is always shared.
+
+```typescript
+sites: {
+  app: {
+    start: 'bun run server.ts',
+    sharedPaths: ['storage', 'public/uploads'],
+  },
+}
+```
+
+A **SQLite database is shared automatically**. The deploy already knows the
+connection and the file path from the environment it writes to the box, so when
+`DB_CONNECTION` is `sqlite` and `DB_DATABASE` names a path inside the release,
+that file is added to `sharedPaths` for you and the deploy log says so. Without
+it the database sits inside a release directory and the next deploy starts the
+app on an empty one — silently, with the data still in a release that is about
+to be pruned.
+
+Two cases it does not cover:
+
+- **`DB_DATABASE` unset.** An app can default its own path internally, which the
+  deploy never sees. Guessing the filename would report the data as safe while
+  sharing a path the app may not use, so the deploy warns instead — set
+  `DB_DATABASE`, or list the file in `sharedPaths` yourself.
+- **An absolute path.** A database outside the release tree already survives; a
+  deploy replaces the release, not the filesystem around it.
+
+Turning existing on-box state into shared state does not throw it away: the
+first deploy to share a path copies the live release's copy into `shared/`
+(SQLite's `-wal`/`-shm` sidecars included), and a site's first deploy seeds a
+still-empty shared file from the copy the artifact shipped.
+
+Several sites of one project can share ONE file — an app and its API on one
+SQLite database — with the object form, which names an absolute `target`:
+
+```typescript
+sharedPaths: [{ path: 'database/app.sqlite', target: '/var/www/acme-app/shared/database/app.sqlite', seed: false }]
+```
+
+Each site installs under its own base, so a plain string would give each of them
+a database of its own. `seed: false` marks the sites that do not own the file.
+
 ### CDN / caching
 
 The `cache` hint applies to either origin:

--- a/docs/config.md
+++ b/docs/config.md
@@ -153,6 +153,36 @@ is often worth making, but it should be a decision rather than a surprise.
 token actually reaches, separating the owner's boxes from the ones no one asked
 for, so the radius can be shown before an attach is approved.
 
+### It cannot install services on the owner's box
+
+Attach mode provisions nothing — installing engines on someone else's server is
+not a tenant's business. So `infrastructure.compute.managedServices` in an
+attached config is a statement about what the HOST already runs, not a request
+to install anything:
+
+```typescript
+cloud: { provider: 'hetzner', attachTo: 'statushq' },
+infrastructure: {
+  appDatabase: { engine: 'postgres', name: 'loghq', username: 'loghq', password: '…' },
+  compute: { managedServices: { postgres: true } },  // statushq must ALREADY run postgres
+}
+```
+
+If the owner's box runs SQLite, there is no Postgres for the tenant's role and
+database to be created in, and nothing will ever install one. The deploy checks
+this before it ships anything and stops with the incompatibility named:
+
+```
+This project declares managedServices.postgres, but 'statushq' has no postgres
+on 203.0.113.10. Attach mode does not provision services on the owner's box, so
+nothing will install it. Point the app at an external service, or ask the owner
+of 'statushq' to add it to their own config and re-provision.
+```
+
+A service counts as present when its binary is on `PATH` or something is
+listening on its port. If the check itself cannot get an answer, the deploy
+proceeds — it is a preflight, not a gate.
+
 ## Two app models
 
 ts-cloud deploys apps two ways; pick per environment:

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1243,6 +1243,11 @@ export interface SiteConfig {
    * A release is a fresh directory, so anything the app WRITES and must keep
    * has to be listed here or the next deploy silently starts it from empty.
    *
+   * A SQLite database is the one exception, added for you: when the site's
+   * resolved env says `DB_CONNECTION=sqlite` and `DB_DATABASE` names a path
+   * inside the release, the deploy shares that file without being asked. An
+   * env that says SQLite but not WHERE is warned about rather than guessed at.
+   *
    * An entry may instead be a {@link SharedPathSpec} naming an absolute
    * `target`, which is how SEVERAL sites of one project point at ONE file —
    * an app and its API sharing a single SQLite database, say. Each site

--- a/packages/ts-cloud/src/drivers/aws/driver.ts
+++ b/packages/ts-cloud/src/drivers/aws/driver.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import { resolveProjectStackName } from '@ts-cloud/core'
 import { CloudFormationClient } from '../../aws/cloudformation'
 import { normalizePublicIpv6 } from '../../deploy/server-dns'
+import { summarizeRemoteFailures } from '../shared/remote-failure'
 import { EC2Client } from '../../aws/ec2'
 import { S3Client } from '../../aws/s3'
 import { SSMClient } from '../../aws/ssm'
@@ -463,7 +464,12 @@ export class AwsDriver implements CloudDriver {
       success,
       instanceCount: perInstance.length,
       perInstance,
-      error: success ? undefined : 'One or more SSM command invocations failed',
+      // Include each failing invocation's StandardErrorContent — callers report
+      // `result.error` alone, so without this the reason is captured and then
+      // dropped on the floor.
+      error: success
+        ? undefined
+        : summarizeRemoteFailures(perInstance, 'One or more SSM command invocations failed'),
     }
   }
 }

--- a/packages/ts-cloud/src/drivers/hetzner/driver.ts
+++ b/packages/ts-cloud/src/drivers/hetzner/driver.ts
@@ -22,6 +22,7 @@ import { generateUbuntuAppCloudInit, wrapCloudInitUserData } from './cloud-init'
 import { resolveHetznerApiToken, resolveHetznerImage, resolveHetznerSettings } from './config'
 import { buildHetznerFirewallRules } from './firewall-rules'
 import { matchesTsCloudLabels, matchesTsCloudProject, resolveHetznerServerType, TS_CLOUD_LABEL_PREFIX, tsCloudLabels } from './instance-sizes'
+import { summarizeRemoteFailures } from '../shared/remote-failure'
 import { readDriverState, writeDriverState } from './state'
 
 /** Output cap for SCP/SSH children — large enough for verbose tar extraction. */
@@ -1277,7 +1278,11 @@ export class HetznerDriver implements CloudDriver {
       success,
       instanceCount: options.targets.length,
       perInstance,
-      error: success ? undefined : 'One or more SSH deploy commands failed',
+      // Carry the failing host's remote output into the error itself. Callers
+      // report `result.error` and nothing else, so a bare summary here is the
+      // difference between "the database ensure failed" and "the database
+      // ensure failed because there is no psql on this box".
+      error: success ? undefined : summarizeRemoteFailures(perInstance, 'One or more SSH deploy commands failed'),
     }
   }
 

--- a/packages/ts-cloud/src/drivers/shared/compute-deploy.ts
+++ b/packages/ts-cloud/src/drivers/shared/compute-deploy.ts
@@ -17,6 +17,7 @@ import { resolveNotifications, sendNotifications } from './notifications'
 import { buildPhpFpmPoolScript, phpFpmPoolListen } from './php-fpm-pool'
 import { buildDeployHistoryHeader, buildSiteOwnerGuard } from './releases'
 import { buildRpxConfig, buildRpxFragmentRefreshScript, buildRpxLbConfig, buildRpxProvisionScript, certDomainsForConfig, rpxCertRenewServiceName, usesRpxProxy } from './rpx-gateway'
+import { inferSqliteSharedPath } from './sqlite-shared-path'
 
 export interface ComputeDeployLogger {
   info(message: string): void
@@ -94,6 +95,14 @@ export async function deploySiteRelease(
     // select Bun's development exports or dev-only runtime paths on the box.
     ...productionEnv,
   }
+
+  // A SQLite database inside the release directory is thrown away by the next
+  // deploy. The script builders share it automatically when the env says where
+  // it lives; when the env says SQLite but not where, only the operator can
+  // resolve it — so say so here rather than deploying quietly over it.
+  const sqlite = inferSqliteSharedPath(envWithServices, site.sharedPaths ?? [])
+  if (sqlite.warning) logger.warn(`Site '${siteName}': ${sqlite.warning}`)
+  else if (sqlite.path) logger.info(`Site '${siteName}': sharing '${sqlite.path}' so the SQLite database survives deploys.`)
 
   // PHP/Laravel sites deploy via git clone + atomic releases on the box (no
   // tarball upload). The box clones the repo, runs the deploy script inside the

--- a/packages/ts-cloud/src/drivers/shared/compute-deploy.ts
+++ b/packages/ts-cloud/src/drivers/shared/compute-deploy.ts
@@ -12,6 +12,7 @@ import { buildDatabaseSetupScript, buildManagedDbEnv } from './db-provision'
 import { buildAwsArtifactFetch, buildHostCleanupScript, buildLocalArtifactFetch, buildSiteDeployScript, buildStaticSiteDeployScript, releaseTarballTmpPath, resolveExecStart } from './deploy-script'
 import { buildFleetServicesEnv } from './fleet'
 import { buildHealthCheckScript, buildLaravelDeployScript } from './laravel-deploy'
+import { buildManagedServicesProbeScript, declaredManagedServices, formatMissingManagedServicesError, parseMissingManagedServices } from './managed-services-probe'
 import { buildNginxVhostScript, resolveNginxSnippet } from './nginx-vhost'
 import { resolveNotifications, sendNotifications } from './notifications'
 import { buildPhpFpmPoolScript, phpFpmPoolListen } from './php-fpm-pool'
@@ -494,6 +495,65 @@ async function reconcileManagementDashboardServices(
 }
 
 /**
+ * Attach mode preflight: does the owner's box actually provide the on-box
+ * services this project declares?
+ *
+ * Attach mode provisions nothing — that is the whole point of riding someone
+ * else's box — so `managedServices` here is a statement about what the HOST is
+ * expected to already run, not a request to install anything. When the host
+ * does not run it, every step built on top of it is doomed: the database ensure
+ * below talks to an engine that is not there, and the app ships with a
+ * connection string pointing at a closed port.
+ *
+ * Catching that here costs one SSH round-trip and turns an afternoon of
+ * guessing into one sentence. A probe that cannot run (no targets, no output)
+ * never blocks the deploy: this is a preflight, not a gate.
+ *
+ * Returns `false` only when the box positively reported a declared service
+ * missing.
+ */
+async function preflightAttachedHostServices(
+  driver: CloudDriver,
+  options: DeployAllSitesOptions,
+  logger: ComputeDeployLogger,
+): Promise<boolean> {
+  const { config, environment } = options
+  const ownerSlug = config.cloud?.attachTo
+  if (!ownerSlug) return true
+
+  const declared = declaredManagedServices(config.infrastructure?.compute?.managedServices)
+  if (declared.length === 0) return true
+
+  const slug = config.project.slug
+  const stackName = resolveProjectStackName(config, environment)
+  const targets = await driver.findComputeTargets({ slug, environment, role: 'app', stackName })
+  // No targets: the site deploy itself reports that error authoritatively.
+  if (targets.length === 0) return true
+
+  const result = await driver.runRemoteDeploy({
+    targets,
+    commands: buildManagedServicesProbeScript(declared),
+    comment: `ts-cloud preflight managed services ${slug}`,
+    tags: { Project: slug, Environment: environment, Role: 'app' },
+  })
+  if (!result.success) {
+    // The probe itself failing says nothing about the services. Deploy on and
+    // let the real work report its own error.
+    logger.warn(`Could not check '${ownerSlug}' for the declared services: ${result.error || 'unknown error'}`)
+    return true
+  }
+
+  const missing = new Set<string>()
+  for (const instance of result.perInstance) {
+    for (const name of parseMissingManagedServices(instance.output, declared)) missing.add(name)
+  }
+  if (missing.size === 0) return true
+
+  logger.error(formatMissingManagedServicesError([...missing], ownerSlug, targets[0]?.publicIp))
+  return false
+}
+
+/**
  * Attach mode (`cloud.attachTo`): this project rides a box its OWNER provisioned,
  * so no cloud-init of ours ever ran the on-box database setup — the tenant role
  * and database simply do not exist unless someone creates them by hand. When the
@@ -652,6 +712,10 @@ export async function deployAllComputeSites(options: DeployAllSitesOptions): Pro
   // written. Returning here left such a project silently untouched — the deploy
   // ran green and the box kept a hand-maintained fragment.
   if (deployable.length === 0) return reloadRpxGateway(options)
+
+  // Attach mode (`cloud.attachTo`): before anything is built ON the owner's
+  // services, confirm the owner's box actually runs them.
+  if (!(await preflightAttachedHostServices(driver, options, logger))) return false
 
   // Attach mode (`cloud.attachTo`): the shared box was provisioned by its OWNER,
   // so no cloud-init of ours ever ran this project's on-box database setup — the

--- a/packages/ts-cloud/src/drivers/shared/deploy-script.ts
+++ b/packages/ts-cloud/src/drivers/shared/deploy-script.ts
@@ -13,6 +13,7 @@
 import type { SharedPathEntry } from '@ts-cloud/core'
 import { formatEnvFile } from './env-file'
 import { buildActivateRelease, buildDeployLock, buildEnsureReleaseLayout, buildLinkSharedPaths, buildPromoteStagedRelease, buildPruneReleases, buildResetReleaseDir, buildStrandedReleaseTrap, dedupeSharedPaths, DEFAULT_KEEP_RELEASES, releasePaths } from './releases'
+import { sqliteSharedPaths } from './sqlite-shared-path'
 
 /**
  * Translate a `start` command (e.g. "bun run server.ts") into an absolute
@@ -184,7 +185,15 @@ export function buildSiteDeployScript(options: BuildSiteDeployScriptOptions): st
   const serviceName = `${unitBase}.service`
   const tarball = releaseTarballTmpPath(slug, siteName, releaseId)
   // `.env` is always shared; a site adds anything else it writes and must keep.
-  const sharedPaths = dedupeSharedPaths(['.env', ...(options.sharedPaths ?? [])])
+  // A SQLite database is added for it: the deploy already knows the connection
+  // and the file path from the env it is about to write, and an undeclared
+  // SQLite file inside the release is discarded by the NEXT deploy.
+  const declaredSharedPaths = options.sharedPaths ?? []
+  const sharedPaths = dedupeSharedPaths([
+    '.env',
+    ...declaredSharedPaths,
+    ...sqliteSharedPaths(envEntries, declaredSharedPaths),
+  ])
 
   const envFile = formatEnvFile(envEntries)
 

--- a/packages/ts-cloud/src/drivers/shared/laravel-deploy.ts
+++ b/packages/ts-cloud/src/drivers/shared/laravel-deploy.ts
@@ -19,6 +19,7 @@ import { formatEnvFile } from './env-file'
 import { buildGitCheckoutScript } from './git-deploy'
 import { PANTRY_PROJECT_DIR, pantryEnvActivation } from './package-manager'
 import { buildActivateRelease, buildDeployHistoryHeader, buildEnsureReleaseLayout, buildLinkSharedPaths, buildPruneReleases, DEFAULT_KEEP_RELEASES, DEFAULT_SHARED_PATHS, releasePaths } from './releases'
+import { sqliteSharedPaths } from './sqlite-shared-path'
 
 export const MACRO_CREATE_RELEASE = '$CREATE_RELEASE'
 export const MACRO_ACTIVATE_RELEASE = '$ACTIVATE_RELEASE'
@@ -142,7 +143,11 @@ export function buildLaravelDeployScript(options: LaravelDeployOptions): string[
   // pinned at install time (php.net@<version>), not in the deploy command.
   const phpBin = 'php'
   const paths = releasePaths(base, releaseId)
-  const sharedPaths = site.sharedPaths ?? DEFAULT_SHARED_PATHS
+  const declaredSharedPaths = site.sharedPaths ?? DEFAULT_SHARED_PATHS
+  // Share the app's SQLite database automatically when the env names one inside
+  // the release — see `./sqlite-shared-path`. A `database/*.sqlite` left out of
+  // `sharedPaths` is thrown away by the next deploy.
+  const sharedPaths = [...declaredSharedPaths, ...sqliteSharedPaths(site.env, declaredSharedPaths)]
   const keepReleases = site.keepReleases ?? DEFAULT_KEEP_RELEASES
   const template = site.deployScript?.length ? site.deployScript : defaultDeployScriptFor(site.type ?? 'laravel')
 

--- a/packages/ts-cloud/src/drivers/shared/managed-services-probe.test.ts
+++ b/packages/ts-cloud/src/drivers/shared/managed-services-probe.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  buildManagedServicesProbeScript,
+  declaredManagedServices,
+  formatMissingManagedServicesError,
+  parseMissingManagedServices,
+} from './managed-services-probe'
+
+describe('declaredManagedServices', () => {
+  it('lists the enabled services, object form included', () => {
+    expect(declaredManagedServices({ postgres: true, redis: { version: '7' }, mysql: false }))
+      .toEqual(['postgres', 'redis'])
+  })
+
+  it('is empty for no config at all', () => {
+    expect(declaredManagedServices(undefined)).toEqual([])
+    expect(declaredManagedServices({})).toEqual([])
+  })
+})
+
+describe('buildManagedServicesProbeScript', () => {
+  it('probes each declared service by binary and by port', () => {
+    const out = buildManagedServicesProbeScript(['postgres', 'redis']).join('\n')
+    expect(out).toContain('ts_cloud_probe postgres 5432 postgres psql')
+    expect(out).toContain('ts_cloud_probe redis 6379 redis-server redis-cli')
+  })
+
+  /**
+   * A missing service is a finding to report, not a remote failure — the probe
+   * must come back with its answer rather than a non-zero exit.
+   */
+  it('always exits 0', () => {
+    expect(buildManagedServicesProbeScript(['postgres']).at(-1)).toBe('exit 0')
+  })
+
+  it('builds nothing when nothing is declared', () => {
+    expect(buildManagedServicesProbeScript([])).toEqual([])
+  })
+})
+
+describe('parseMissingManagedServices', () => {
+  it('reports only what the box said was missing', () => {
+    const output = 'ts-cloud-service:postgres:missing\nts-cloud-service:redis:present\n'
+    expect(parseMissingManagedServices(output, ['postgres', 'redis'])).toEqual(['postgres'])
+  })
+
+  /**
+   * Silence is not evidence of absence: an older box, or a truncated capture,
+   * must not invent a failure and block a deploy that is fine.
+   */
+  it('reports nothing when the probe said nothing', () => {
+    expect(parseMissingManagedServices('', ['postgres'])).toEqual([])
+    expect(parseMissingManagedServices(undefined, ['postgres'])).toEqual([])
+    expect(parseMissingManagedServices('some unrelated output', ['postgres'])).toEqual([])
+  })
+})
+
+describe('formatMissingManagedServicesError', () => {
+  it('names the setting, the owner, the host, and the ways out', () => {
+    const message = formatMissingManagedServicesError(['postgres'], 'uptime-status', '10.0.0.1')
+    expect(message).toContain('managedServices.postgres')
+    expect(message).toContain("'uptime-status'")
+    expect(message).toContain('10.0.0.1')
+    expect(message).toContain('Attach mode does not provision services')
+  })
+
+  it('reads correctly for several services', () => {
+    const message = formatMissingManagedServicesError(['postgres', 'redis'], 'owner', undefined)
+    expect(message).toContain('managedServices.postgres, managedServices.redis')
+    expect(message).toContain('none of postgres, redis')
+  })
+})

--- a/packages/ts-cloud/src/drivers/shared/managed-services-probe.ts
+++ b/packages/ts-cloud/src/drivers/shared/managed-services-probe.ts
@@ -1,0 +1,126 @@
+/**
+ * Check that a box actually runs the on-box services a project declares.
+ *
+ * This exists for attach mode (`cloud.attachTo`). A project that attaches rides
+ * a box its OWNER provisioned, and attach mode deliberately provisions nothing:
+ * installing engines on someone else's server is not a tenant's business. But
+ * the tenant's config still carries `managedServices`, and ts-cloud used to act
+ * on it regardless — creating a role and database against an engine that was
+ * never there. The result was a deploy that shipped every release and then
+ * failed at the database step, with no statement anywhere that the two settings
+ * are structurally incompatible.
+ *
+ * A declared service is considered present when its binary is on PATH (pantry
+ * puts the engines there) OR something is listening on its port. Either alone
+ * is enough on purpose: a stopped service and an engine installed outside
+ * pantry are both "the owner has this", and a preflight that fails on those
+ * would block deploys it has no business blocking. The case worth catching is
+ * the unambiguous one — no binary, no listener, no engine.
+ */
+import type { ComputeServicesConfig } from '@ts-cloud/core'
+import { pantryEnvActivation } from './package-manager'
+
+/** How to recognize each on-box service the config can declare. */
+const SERVICE_PROBES: Record<string, { port: number; binaries: string[] }> = {
+  // `mysqld`/`mariadbd` are the servers; the clients are listed too because a
+  // box pointing at its own engine always has one.
+  mysql: { port: 3306, binaries: ['mysqld', 'mysql'] },
+  mariadb: { port: 3306, binaries: ['mariadbd', 'mariadb', 'mysqld'] },
+  postgres: { port: 5432, binaries: ['postgres', 'psql'] },
+  redis: { port: 6379, binaries: ['redis-server', 'redis-cli'] },
+  memcached: { port: 11211, binaries: ['memcached'] },
+  meilisearch: { port: 7700, binaries: ['meilisearch'] },
+  // Apps reach Vitess through vtgate, never the tablet's mysqld.
+  vitess: { port: 15306, binaries: ['vtgate'] },
+}
+
+/** Marker prefix the probe prints, one line per service. */
+const MARKER = 'ts-cloud-service:'
+
+function isEnabled(spec: boolean | { version?: string } | object | undefined): boolean {
+  return spec === true || (typeof spec === 'object' && spec != null)
+}
+
+/**
+ * The service names a config declares, in a stable order. Unknown keys are
+ * skipped rather than guessed at: a service this module cannot recognize is one
+ * it cannot honestly report as missing.
+ */
+export function declaredManagedServices(services: ComputeServicesConfig | undefined): string[] {
+  if (!services) return []
+  return Object.keys(SERVICE_PROBES).filter(name => isEnabled((services as Record<string, unknown>)[name] as never))
+}
+
+/**
+ * Shell that reports which of `names` the box provides, one `ts-cloud-service:`
+ * line each. Always exits 0 — a missing service is a finding to report, not a
+ * remote command failure to guess at.
+ */
+export function buildManagedServicesProbeScript(names: readonly string[]): string[] {
+  if (names.length === 0) return []
+  return [
+    // Engines installed by ts-cloud live in the pantry project, not on the
+    // default PATH.
+    pantryEnvActivation(),
+    'ts_cloud_port_open() {',
+    '  if command -v ss >/dev/null 2>&1; then ss -ltn 2>/dev/null | grep -qE "[:.]$1[[:space:]]" && return 0; fi',
+    '  if command -v netstat >/dev/null 2>&1; then netstat -ltn 2>/dev/null | grep -qE "[:.]$1[[:space:]]" && return 0; fi',
+    // Last resort on a box with neither tool: bash can open the socket itself.
+    '  (exec 3<>/dev/tcp/127.0.0.1/$1) 2>/dev/null && { exec 3<&- 3>&-; return 0; }',
+    '  return 1',
+    '}',
+    'ts_cloud_probe() {',
+    '  TS_CLOUD_SVC="$1"; TS_CLOUD_PORT="$2"; shift 2',
+    '  for TS_CLOUD_BIN in "$@"; do',
+    `    if command -v "$TS_CLOUD_BIN" >/dev/null 2>&1; then echo "${MARKER}$TS_CLOUD_SVC:present"; return 0; fi`,
+    '  done',
+    `  if ts_cloud_port_open "$TS_CLOUD_PORT"; then echo "${MARKER}$TS_CLOUD_SVC:present"; return 0; fi`,
+    `  echo "${MARKER}$TS_CLOUD_SVC:missing"`,
+    '  return 0',
+    '}',
+    ...names
+      .filter(name => SERVICE_PROBES[name])
+      .map(name => `ts_cloud_probe ${name} ${SERVICE_PROBES[name].port} ${SERVICE_PROBES[name].binaries.join(' ')}`),
+    'exit 0',
+  ]
+}
+
+/**
+ * The declared services the box reported as missing.
+ *
+ * A service the probe said nothing about is NOT reported missing: silence means
+ * the probe did not run (an older box, a truncated capture), and inventing a
+ * failure from missing evidence would block deploys that are perfectly fine.
+ */
+export function parseMissingManagedServices(output: string | undefined, declared: readonly string[]): string[] {
+  if (!output) return []
+  const status = new Map<string, string>()
+  for (const line of output.split('\n')) {
+    const marker = line.indexOf(MARKER)
+    if (marker === -1) continue
+    const [name, state] = line.slice(marker + MARKER.length).trim().split(':')
+    if (name) status.set(name, state)
+  }
+  return declared.filter(name => status.get(name) === 'missing')
+}
+
+/**
+ * The message an operator gets when the host does not provide what the tenant
+ * declared. Names the setting, the owner, the host, and the two ways out —
+ * because the one thing that is NOT an option is waiting for ts-cloud to
+ * install it.
+ */
+export function formatMissingManagedServicesError(
+  missing: readonly string[],
+  ownerSlug: string,
+  host: string | undefined,
+): string {
+  const where = host ? ` on ${host}` : ''
+  const list = missing.map(name => `managedServices.${name}`).join(', ')
+  const subject = missing.length === 1 ? `no ${missing[0]}` : `none of ${missing.join(', ')}`
+  return (
+    `This project declares ${list}, but '${ownerSlug}' has ${subject}${where}. `
+    + `Attach mode does not provision services on the owner's box, so nothing will install ${missing.length === 1 ? 'it' : 'them'}. `
+    + `Point the app at an external service, or ask the owner of '${ownerSlug}' to add ${missing.length === 1 ? 'it' : 'them'} to their own config and re-provision.`
+  )
+}

--- a/packages/ts-cloud/src/drivers/shared/releases.ts
+++ b/packages/ts-cloud/src/drivers/shared/releases.ts
@@ -340,6 +340,31 @@ export function buildPromoteStagedRelease(paths: ReleasePaths): string[] {
 }
 
 /**
+ * Seed an as-yet-empty shared FILE from the copy the incoming release shipped.
+ *
+ * {@link buildAdoptSharedPathFn} rescues state from the release that is
+ * currently live, which covers a path that becomes shared on an existing site.
+ * It cannot cover a site's FIRST deploy: there is no live release to adopt
+ * from, so the layout step leaves a zero-byte placeholder and the link below
+ * would replace the artifact's real file with it — an app shipping a seeded
+ * SQLite database would come up empty on the very deploy that created it.
+ *
+ * Narrow on purpose: only a regular, non-empty file in the release, and only
+ * when the shared target is still zero bytes (what a placeholder looks like,
+ * and what no real SQLite database ever is — a database with any schema in it
+ * is at least one page). It can therefore only ever put content where there
+ * was none.
+ */
+function buildSeedSharedFromRelease(link: string, target: string): string[] {
+  return [
+    `if [ -f ${link} ] && [ ! -L ${link} ] && [ -s ${link} ] && [ ! -s ${target} ]; then`,
+    `  cp -a ${link} ${target}`,
+    `  echo "[ts-cloud] seeded shared/ from the release's own copy of the file"`,
+    'fi',
+  ]
+}
+
+/**
  * Symlink every shared path from `shared/` into the freshly checked-out release,
  * replacing whatever the checkout shipped (e.g. the repo's empty `storage`).
  */
@@ -355,6 +380,9 @@ export function buildLinkSharedPaths(
 
     // A site that owns the target always links: the layout step just created it.
     if (seed) {
+      // `.env` is excluded: the deploy writes the shared one itself, and the
+      // release's own env files are deleted before this runs.
+      if (p !== '.env' && isFileSharedPath(p)) lines.push(...buildSeedSharedFromRelease(link, target))
       lines.push(...relink)
       continue
     }

--- a/packages/ts-cloud/src/drivers/shared/remote-failure.test.ts
+++ b/packages/ts-cloud/src/drivers/shared/remote-failure.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'bun:test'
+import { summarizeRemoteFailures } from './remote-failure'
+
+describe('summarizeRemoteFailures', () => {
+  /**
+   * The failure this fixes: "One or more SSH deploy commands failed" was the
+   * ENTIRE error an operator got, while the line explaining it sat unused in
+   * perInstance.
+   */
+  it('appends the failing instance output to the summary', () => {
+    const message = summarizeRemoteFailures(
+      [{ instanceId: 'i-1', status: 'Failed', error: 'Remote SSH command failed (exit 127)\npsql: command not found' }],
+      'One or more SSH deploy commands failed',
+    )
+    expect(message).toContain('One or more SSH deploy commands failed')
+    expect(message).toContain('i-1: Failed')
+    expect(message).toContain('psql: command not found')
+  })
+
+  it('falls back to stdout when nothing was captured on stderr', () => {
+    const message = summarizeRemoteFailures(
+      [{ instanceId: 'i-1', status: 'Failed', output: 'ERROR: role "loghq" cannot be created' }],
+      'failed',
+    )
+    expect(message).toContain('role "loghq" cannot be created')
+  })
+
+  it('ignores the instances that succeeded', () => {
+    const message = summarizeRemoteFailures(
+      [
+        { instanceId: 'i-ok', status: 'Success', output: 'all good' },
+        { instanceId: 'i-bad', status: 'Failed', error: 'boom' },
+      ],
+      'failed',
+    )
+    expect(message).toContain('i-bad')
+    expect(message).not.toContain('i-ok')
+  })
+
+  it('counts the instances it does not quote', () => {
+    const message = summarizeRemoteFailures(
+      Array.from({ length: 5 }, (_, i) => ({ instanceId: `i-${i}`, status: 'Failed', error: 'boom' })),
+      'failed',
+    )
+    expect(message).toContain('(+2 more instances failed)')
+  })
+
+  it('keeps the tail of a long output, where the failure is named', () => {
+    const long = `${'noise\n'.repeat(2000)}FATAL: the actual reason`
+    const message = summarizeRemoteFailures([{ instanceId: 'i-1', status: 'Failed', error: long }], 'failed')
+    expect(message).toContain('FATAL: the actual reason')
+    expect(message.length).toBeLessThan(long.length)
+  })
+
+  it('returns the bare summary when nothing is marked failed', () => {
+    expect(summarizeRemoteFailures([], 'failed')).toBe('failed')
+  })
+})

--- a/packages/ts-cloud/src/drivers/shared/remote-failure.ts
+++ b/packages/ts-cloud/src/drivers/shared/remote-failure.ts
@@ -1,0 +1,54 @@
+/**
+ * Turn per-instance remote-execution results into ONE operator-facing error.
+ *
+ * Both drivers used to collapse a failed remote run to a fixed sentence —
+ * "One or more SSH deploy commands failed" — while the thing that explains the
+ * failure (the remote command's stderr) sat right there in `perInstance`. The
+ * operator was left with a deploy that had failed for no stated reason, and no
+ * flag, not even `--verbose`, would print it: nothing had kept it.
+ *
+ * The remote output is already redacted where it is captured (the deploy script
+ * embeds a here-document with the full runtime environment; see
+ * `formatSshFailure`), so this only has to decide what is worth showing.
+ */
+import type { RemoteDeployInstanceResult } from '@ts-cloud/core'
+
+/** Longest remote output carried into the aggregate error, per instance. */
+const PER_INSTANCE_LIMIT = 4_000
+
+/** Instances beyond this are summarized as a count rather than quoted. */
+const MAX_QUOTED_INSTANCES = 3
+
+function clip(value: string): string {
+  // Keep the TAIL: a failing script's last lines are the ones that name the
+  // failure, while the head is setup noise.
+  return value.length > PER_INSTANCE_LIMIT ? `…\n${value.slice(-PER_INSTANCE_LIMIT)}` : value
+}
+
+/**
+ * Build the `error` for a {@link import('@ts-cloud/core').RemoteDeployResult}
+ * whose run did not fully succeed. `summary` is the one-line what-failed (e.g.
+ * "One or more SSH deploy commands failed"); the detail of each failing
+ * instance is appended beneath it.
+ */
+export function summarizeRemoteFailures(
+  perInstance: readonly RemoteDeployInstanceResult[],
+  summary: string,
+): string {
+  const failed = perInstance.filter(item => item.status !== 'Success')
+  if (failed.length === 0) return summary
+
+  const quoted = failed.slice(0, MAX_QUOTED_INSTANCES).map((item) => {
+    // Prefer the captured error (stderr + exit status); fall back to stdout,
+    // which is where a script that reports its own failure and exits non-zero
+    // without writing to stderr leaves the explanation.
+    const detail = (item.error || item.output || '').trim()
+    const head = `${item.instanceId}: ${item.status}`
+    return detail ? `${head}\n${clip(detail)}` : head
+  })
+
+  const remaining = failed.length - quoted.length
+  const more = remaining > 0 ? [`(+${remaining} more instance${remaining === 1 ? '' : 's'} failed)`] : []
+
+  return [summary, ...quoted, ...more].join('\n')
+}

--- a/packages/ts-cloud/src/drivers/shared/sqlite-shared-path.test.ts
+++ b/packages/ts-cloud/src/drivers/shared/sqlite-shared-path.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'bun:test'
+import { buildSiteDeployScript } from './deploy-script'
+import { inferSqliteSharedPath, sqliteSharedPaths, usesSqlite } from './sqlite-shared-path'
+
+describe('inferSqliteSharedPath', () => {
+  it('shares a release-relative sqlite file', () => {
+    expect(inferSqliteSharedPath({ DB_CONNECTION: 'sqlite', DB_DATABASE: 'database/stacks.sqlite' }))
+      .toEqual({ path: 'database/stacks.sqlite' })
+  })
+
+  it('accepts the sqlite3 spelling and a leading ./', () => {
+    expect(inferSqliteSharedPath({ DB_CONNECTION: 'SQLite3', DB_DATABASE: './database/app.sqlite' }))
+      .toEqual({ path: 'database/app.sqlite' })
+  })
+
+  it('leaves a non-sqlite app alone', () => {
+    expect(inferSqliteSharedPath({ DB_CONNECTION: 'pgsql', DB_DATABASE: 'loghq' })).toEqual({})
+    expect(usesSqlite({ DB_CONNECTION: 'mysql' })).toBe(false)
+  })
+
+  /**
+   * A path outside the release is not replaced by a deploy — it needs no
+   * shared/ entry, and inventing one would symlink a path the app does not use.
+   */
+  it('leaves an absolute path alone', () => {
+    expect(inferSqliteSharedPath({ DB_CONNECTION: 'sqlite', DB_DATABASE: '/var/data/app.sqlite' })).toEqual({})
+  })
+
+  it('refuses a path escaping the release', () => {
+    expect(inferSqliteSharedPath({ DB_CONNECTION: 'sqlite', DB_DATABASE: '../shared/app.sqlite' })).toEqual({})
+  })
+
+  it('leaves an in-memory database alone', () => {
+    expect(inferSqliteSharedPath({ DB_CONNECTION: 'sqlite', DB_DATABASE: ':memory:' })).toEqual({})
+  })
+
+  /**
+   * Guessing the filename would report the data as safe while sharing a path
+   * the app may never write. Say what is unknown instead.
+   */
+  it('warns when the app is on sqlite but names no file', () => {
+    const { path, warning } = inferSqliteSharedPath({ DB_CONNECTION: 'sqlite' })
+    expect(path).toBeUndefined()
+    expect(warning).toContain('DB_DATABASE')
+  })
+
+  it('does not duplicate a path the site already declares', () => {
+    const env = { DB_CONNECTION: 'sqlite', DB_DATABASE: 'database/app.sqlite' }
+    expect(inferSqliteSharedPath(env, ['database/app.sqlite'])).toEqual({})
+    // Including the spec form, which is how sibling sites share one database.
+    expect(inferSqliteSharedPath(env, [{ path: 'database/app.sqlite', target: '/var/www/api/shared/db.sqlite' }]))
+      .toEqual({})
+    expect(sqliteSharedPaths(env, ['database/app.sqlite'])).toEqual([])
+  })
+})
+
+describe('server-app deploy script', () => {
+  const script = (env: Record<string, string>): string =>
+    buildSiteDeployScript({
+      siteName: 'app',
+      slug: 'acme',
+      artifactFetch: [],
+      releaseId: 'rel1',
+      execStart: '/usr/local/bin/bun run server.ts',
+      envEntries: env,
+      port: 3000,
+    }).join('\n')
+
+  /**
+   * The failure this guards against: a SQLite file written inside the release
+   * directory, which the NEXT deploy leaves behind in a pruned release.
+   */
+  it('shares the sqlite database without being told to', () => {
+    const out = script({ DB_CONNECTION: 'sqlite', DB_DATABASE: 'database/stacks.sqlite' })
+    expect(out).toContain('/var/www/app/shared/database/stacks.sqlite')
+    expect(out).toContain('ln -sfn /var/www/app/shared/database/stacks.sqlite /var/www/app/releases/rel1/database/stacks.sqlite')
+  })
+
+  it('records it in the shared-paths manifest, so a rollback relinks it', () => {
+    const out = script({ DB_CONNECTION: 'sqlite', DB_DATABASE: 'database/stacks.sqlite' })
+    expect(out).toContain('database/stacks.sqlite\t/var/www/app/shared/database/stacks.sqlite')
+  })
+
+  it('adopts the live copy before placeholding it, so existing data is not lost', () => {
+    const out = script({ DB_CONNECTION: 'sqlite', DB_DATABASE: 'database/stacks.sqlite' })
+    const adopt = out.indexOf("ts_cloud_adopt_shared 'database/stacks.sqlite'")
+    const touch = out.indexOf('touch /var/www/app/shared/database/stacks.sqlite')
+    expect(adopt).toBeGreaterThan(-1)
+    expect(touch).toBeGreaterThan(adopt)
+  })
+
+  it('adds nothing for a postgres app', () => {
+    const out = script({ DB_CONNECTION: 'pgsql', DB_DATABASE: 'loghq' })
+    expect(out).not.toContain('shared/loghq')
+  })
+})

--- a/packages/ts-cloud/src/drivers/shared/sqlite-shared-path.ts
+++ b/packages/ts-cloud/src/drivers/shared/sqlite-shared-path.ts
@@ -1,0 +1,123 @@
+/**
+ * Infer the shared path for an app whose database is SQLite.
+ *
+ * A release directory is disposable: the next deploy is a NEW directory and the
+ * old one is pruned. Anything the app writes and must keep therefore has to live
+ * in `shared/` and be symlinked in (see {@link import('./releases')}). `.env` is
+ * shared implicitly; everything else has to be declared in `site.sharedPaths`.
+ *
+ * A SQLite database is the one case ts-cloud can work out on its own, because
+ * the connection and the file path are already in the environment it writes to
+ * the box. Left undeclared, the file lands inside the release, and the deploy
+ * after it starts the app on an empty database with no warning — the whole
+ * dataset is one deploy from being orphaned inside a pruned release.
+ *
+ * So: read `DB_CONNECTION`/`DB_DATABASE` out of the site's resolved env, and
+ * when they describe a release-relative SQLite file, share it automatically.
+ * When they say SQLite but do not say where, say so loudly instead of guessing
+ * a filename — a wrong guess would share a path the app never writes and leave
+ * the real database exactly as exposed, while reporting that it is safe.
+ */
+import type { SharedPathEntry } from '@ts-cloud/core'
+import { sharedPathOf } from './releases'
+
+/**
+ * `DB_CONNECTION` values that mean "a SQLite file on this box". Stacks and
+ * Laravel both spell it `sqlite`; `sqlite3` shows up in hand-written configs
+ * and PDO DSNs.
+ */
+const SQLITE_CONNECTIONS = new Set(['sqlite', 'sqlite3'])
+
+/** In-memory databases have no file to keep — nothing to share, nothing to warn about. */
+const IN_MEMORY = new Set([':memory:', 'memory'])
+
+/** Is this site's resolved environment pointing at a SQLite database? */
+export function usesSqlite(env: Record<string, string | undefined> | undefined): boolean {
+  const connection = env?.DB_CONNECTION?.trim().toLowerCase()
+  return connection != null && SQLITE_CONNECTIONS.has(connection)
+}
+
+/**
+ * Normalize the configured database path to a release-relative one.
+ *
+ * Returns `undefined` when the path is not release-relative — absolute (it
+ * already lives outside the release and survives on its own) or escaping the
+ * release via `..` (which `shared/` cannot express, and which a symlink would
+ * point somewhere surprising).
+ */
+function releaseRelativePath(value: string): string | undefined {
+  const trimmed = value.trim().replace(/^\.\//, '')
+  if (trimmed === '' || trimmed.startsWith('/') || trimmed.startsWith('~')) return undefined
+  if (trimmed.split('/').includes('..')) return undefined
+  return trimmed.replace(/\/+$/, '')
+}
+
+export interface SqliteSharedPathInference {
+  /**
+   * Release-relative path to add to the site's shared paths. Absent when the
+   * app is not on SQLite, the file already survives deploys, or the path could
+   * not be determined.
+   */
+  path?: string
+  /**
+   * Why nothing could be inferred even though the app IS on SQLite — an
+   * operator-facing sentence naming what to declare. Absent when there is
+   * nothing to worry about.
+   */
+  warning?: string
+}
+
+/**
+ * Work out whether a site's SQLite database needs to be added to its shared
+ * paths, given the environment the deploy writes to the box and whatever the
+ * site already declares.
+ */
+export function inferSqliteSharedPath(
+  env: Record<string, string | undefined> | undefined,
+  declared: readonly SharedPathEntry[] = [],
+): SqliteSharedPathInference {
+  if (!usesSqlite(env)) return {}
+
+  const configured = env?.DB_DATABASE?.trim()
+  // An in-memory database has no file to keep — nothing to share, and nothing
+  // an operator could do about it if there were.
+  if (configured && IN_MEMORY.has(configured.toLowerCase())) return {}
+
+  if (!configured) {
+    // An app can default its own database path internally (Stacks writes
+    // `database/stacks.sqlite`), which the deploy never sees. Guessing that
+    // filename would share a path the app may not use and report the data as
+    // safe when it is not, so name the problem instead.
+    return {
+      warning:
+        'DB_CONNECTION is sqlite but DB_DATABASE names no file, so ts-cloud cannot tell where the database lives. '
+        + 'If it is written inside the release directory, the next deploy discards it. '
+        + "Set DB_DATABASE, or list the file in the site's `sharedPaths`.",
+    }
+  }
+
+  const relative = releaseRelativePath(configured)
+  // Absolute (or `..`-escaping) paths are outside the release tree already —
+  // a deploy replaces the release, not the filesystem around it.
+  if (!relative) return {}
+
+  // Already declared — the operator's own entry wins, including a
+  // `SharedPathSpec` pointing at a database shared with a sibling site.
+  if (declared.some(entry => sharedPathOf(entry) === relative)) return {}
+
+  return { path: relative }
+}
+
+/**
+ * The shared-path entries to append for a site's SQLite database — `[]` when
+ * there is nothing to add. Kept separate from {@link inferSqliteSharedPath} so
+ * script builders can splice it in without having to care about the warning,
+ * which only the deploy driver can surface.
+ */
+export function sqliteSharedPaths(
+  env: Record<string, string | undefined> | undefined,
+  declared: readonly SharedPathEntry[] = [],
+): SharedPathEntry[] {
+  const { path } = inferSqliteSharedPath(env, declared)
+  return path ? [path] : []
+}

--- a/packages/ts-cloud/test/drivers/compute-deploy.test.ts
+++ b/packages/ts-cloud/test/drivers/compute-deploy.test.ts
@@ -912,9 +912,11 @@ describe('deployAllComputeSites attach-mode database ensure', () => {
     const { ok, driver } = await deploy(attachConfig('canonical', 'stacks'))
     expect(ok).toBe(true)
     const calls = (driver.runRemoteDeploy as ReturnType<typeof mock>).mock.calls
-    // One dashboard reconciliation, one ensure, and one site deploy call.
-    expect(calls.length).toBe(3)
-    const ensure = calls[1][0]
+    // One dashboard reconciliation, one managed-services preflight, one ensure,
+    // and one site deploy call.
+    expect(calls.length).toBe(4)
+    expect(calls[1][0].commands.join('\n')).toContain('ts_cloud_probe postgres')
+    const ensure = calls[2][0]
     const sql = ensure.commands.join('\n')
     // Same idempotent script the provisioning path runs at first boot.
     expect(sql).toContain("IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'training')")
@@ -927,15 +929,15 @@ describe('deployAllComputeSites attach-mode database ensure', () => {
     expect(ensure.comment).toBe('ts-cloud ensure database training/training')
     // The ensure strictly precedes the site deploy so the app's first boot
     // already finds its database.
-    expect(calls[2][0].commands.join('\n')).toContain('systemctl restart training-web@abc.service')
+    expect(calls[3][0].commands.join('\n')).toContain('systemctl restart training-web@abc.service')
   })
 
   it('honors the deprecated infrastructure.compute.database alias (bughq shape)', async () => {
     const { ok, driver } = await deploy(attachConfig('legacy', 'stacks'))
     expect(ok).toBe(true)
     const calls = (driver.runRemoteDeploy as ReturnType<typeof mock>).mock.calls
-    expect(calls.length).toBe(3)
-    const sql = calls[1][0].commands.join('\n')
+    expect(calls.length).toBe(4)
+    const sql = calls[2][0].commands.join('\n')
     expect(sql).toContain('CREATE ROLE "training" LOGIN PASSWORD \'pw\'')
     expect(sql).toContain('CREATE DATABASE "training" OWNER "training"')
   })
@@ -953,8 +955,10 @@ describe('deployAllComputeSites attach-mode database ensure', () => {
     const { ok, driver } = await deploy(attachConfig('none', 'stacks'))
     expect(ok).toBe(true)
     const calls = (driver.runRemoteDeploy as ReturnType<typeof mock>).mock.calls
-    expect(calls.length).toBe(2)
-    expect(calls[0][0].commands.join('\n')).not.toContain('CREATE DATABASE')
+    // Dashboard reconciliation, the managed-services preflight, and the site
+    // deploy — no ensure, because there is no database to ensure.
+    expect(calls.length).toBe(3)
+    expect(calls.map((call: any[]) => call[0].commands.join('\n')).join('\n')).not.toContain('CREATE DATABASE')
   })
 
   it('fails the deploy (shipping nothing) when the database ensure fails', async () => {
@@ -975,5 +979,124 @@ describe('deployAllComputeSites attach-mode database ensure', () => {
     expect(ok).toBe(false)
     // The site deploy must never run after a failed ensure.
     expect((driver.runRemoteDeploy as ReturnType<typeof mock>).mock.calls.length).toBe(1)
+  })
+})
+
+/**
+ * Attach mode rides a box its OWNER provisioned and provisions nothing itself,
+ * so `managedServices` here is a claim about the host rather than a request.
+ * When the host does not honour it, every later step is built on an engine that
+ * is not there — which is how a deploy shipped both releases and then died on
+ * "Ensuring database 'loghq' failed" with nothing else to go on.
+ */
+describe('deployAllComputeSites attach-mode service preflight', () => {
+  function attachedConfig(): CloudConfig {
+    return {
+      project: { name: 'Log HQ', slug: 'loghq', region: 'fsn1' },
+      environments: { production: { type: 'production' } },
+      cloud: { provider: 'hetzner', attachTo: 'uptime-status' },
+      sites: { web: { domain: 'loghq.example.com', port: 3000, root: '.output', start: 'bun run server.ts' } },
+      infrastructure: {
+        appDatabase: { engine: 'postgres', name: 'loghq', username: 'loghq', password: 'secret' },
+        compute: { runtime: 'bun', managedServices: { postgres: true }, proxy: { engine: 'rpx' } },
+      },
+    }
+  }
+
+  function run(driver: CloudDriver, config: CloudConfig, errors: string[]): Promise<boolean> {
+    const tempDir = mkdtempSync(join(tmpdir(), 'ts-cloud-attach-'))
+    const tarball = join(tempDir, 'release.tar.gz')
+    writeFileSync(tarball, 'fake tarball')
+    process.env.TS_CLOUD_UI_DISABLE = '1'
+    return deployAllComputeSites({
+      config,
+      environment: 'production',
+      driver,
+      sha: 'abc',
+      runtime: 'bun',
+      tarballForSite: () => tarball,
+      logger: {
+        info: () => {},
+        warn: () => {},
+        error: (message: string) => errors.push(message),
+        step: () => {},
+        success: () => {},
+      },
+    }).finally(() => {
+      delete process.env.TS_CLOUD_UI_DISABLE
+      rmSync(tempDir, { recursive: true, force: true })
+    })
+  }
+
+  it('refuses before shipping anything when the host has no postgres', async () => {
+    const driver = createMockDriver({
+      name: 'hetzner',
+      usesCloudFormation: false,
+      runRemoteDeploy: mock(async (options: { commands: string[] }) => ({
+        success: true,
+        instanceCount: 1,
+        perInstance: [
+          {
+            instanceId: 'i-abc123',
+            status: 'Success',
+            output: options.commands.join('\n').includes('ts_cloud_probe postgres')
+              ? 'ts-cloud-service:postgres:missing'
+              : '',
+          },
+        ],
+      })),
+    })
+    const errors: string[] = []
+    expect(await run(driver, attachedConfig(), errors)).toBe(false)
+    expect(errors.join('\n')).toContain('managedServices.postgres')
+    expect(errors.join('\n')).toContain("'uptime-status'")
+    // The probe ran; the release upload never did.
+    expect(driver.uploadRelease).not.toHaveBeenCalled()
+  })
+
+  it('proceeds when the host provides what was declared', async () => {
+    const driver = createMockDriver({
+      name: 'hetzner',
+      usesCloudFormation: false,
+      runRemoteDeploy: mock(async () => ({
+        success: true,
+        instanceCount: 1,
+        perInstance: [{ instanceId: 'i-abc123', status: 'Success', output: 'ts-cloud-service:postgres:present' }],
+      })),
+    })
+    const errors: string[] = []
+    expect(await run(driver, attachedConfig(), errors)).toBe(true)
+    expect(errors).toEqual([])
+  })
+
+  /**
+   * A preflight that cannot get an answer must not become a gate: an older box
+   * or a truncated capture would otherwise block deploys that are perfectly
+   * fine.
+   */
+  it('does not block when the probe returns nothing', async () => {
+    const driver = createMockDriver({
+      name: 'hetzner',
+      usesCloudFormation: false,
+      runRemoteDeploy: mock(async () => ({
+        success: true,
+        instanceCount: 1,
+        perInstance: [{ instanceId: 'i-abc123', status: 'Success' }],
+      })),
+    })
+    const errors: string[] = []
+    expect(await run(driver, attachedConfig(), errors)).toBe(true)
+  })
+
+  it('probes nothing for a project that owns its box', async () => {
+    const config = attachedConfig()
+    delete config.cloud
+    const driver = createMockDriver({ name: 'hetzner', usesCloudFormation: false })
+    const errors: string[] = []
+    expect(await run(driver, config, errors)).toBe(true)
+    const commands = (driver.runRemoteDeploy as ReturnType<typeof mock>).mock.calls
+      .map((call: any[]) => call[0].commands.join('\n'))
+      .join('\n')
+    expect(commands).not.toContain('ts_cloud_probe')
   })
 })

--- a/packages/ts-cloud/test/drivers/shared-paths.test.ts
+++ b/packages/ts-cloud/test/drivers/shared-paths.test.ts
@@ -154,3 +154,46 @@ describe('shared paths pointed at a project-level target', () => {
     expect(buildLinkSharedPaths(paths, [spec]).join('\n')).not.toContain('if [ -e ')
   })
 })
+
+/**
+ * Adoption rescues state from the LIVE release, which covers a path that
+ * becomes shared on an existing site. A site's FIRST deploy has no live release
+ * to adopt from, so without this the empty placeholder would replace whatever
+ * the artifact shipped — an app shipping a seeded SQLite database would come up
+ * empty on the very deploy that created it.
+ */
+describe('seeding a shared file from the incoming release', () => {
+  const link = (shared: SharedPathEntry[]): string => buildLinkSharedPaths(paths, shared).join('\n')
+
+  it('copies the release copy in when the shared file is still a placeholder', () => {
+    const out = link(['database/app.sqlite'])
+    expect(out).toContain('if [ -f /var/www/site/releases/rel1/database/app.sqlite ]')
+    expect(out).toContain('[ ! -s /var/www/site/shared/database/app.sqlite ]')
+    expect(out).toContain('cp -a /var/www/site/releases/rel1/database/app.sqlite /var/www/site/shared/database/app.sqlite')
+  })
+
+  it('still links the shared file afterwards', () => {
+    const out = link(['database/app.sqlite'])
+    const seed = out.indexOf('cp -a /var/www/site/releases/rel1/database/app.sqlite')
+    const ln = out.indexOf('ln -sfn /var/www/site/shared/database/app.sqlite')
+    expect(seed).toBeGreaterThan(-1)
+    expect(ln).toBeGreaterThan(seed)
+  })
+
+  it('leaves .env alone — the deploy writes the shared one itself', () => {
+    expect(link(['.env'])).not.toContain('cp -a')
+  })
+
+  it('leaves directories alone', () => {
+    expect(link(['storage'])).not.toContain('cp -a')
+  })
+
+  /**
+   * A site that does not own the target must not seed it: the owner's own
+   * deploy adopts or writes it, and a copy from here would make that a no-op.
+   */
+  it('leaves a target this site does not own alone', () => {
+    expect(link([{ path: 'database/app.sqlite', target: '/var/www/api/shared/app.sqlite', seed: false }]))
+      .not.toContain('cp -a')
+  })
+})


### PR DESCRIPTION
Closes #172. Closes #173.

## #172 — a SQLite database in a release directory is discarded on the next deploy

`sharedPaths` already exists for this and its documentation describes this exact case, but it defaults to `['.env']`. So on a live box, `current/database/stacks.sqlite` is a regular 900 KB file and `shared/` holds only `.env` — one deploy from being orphaned in a pruned release, with nothing warning about it.

The engine is the one thing ts-cloud can infer without being told: the deploy already resolves `DB_CONNECTION`/`DB_DATABASE` into the env it writes to the box.

- `DB_CONNECTION=sqlite` + a **release-relative** `DB_DATABASE` → the file is added to the site's shared paths automatically, and the deploy log says so.
- `DB_CONNECTION=sqlite` + **no** `DB_DATABASE` (an app defaulting its own path internally) → warn. Guessing the filename would share a path the app may never write while reporting the data as safe.
- An **absolute** path → left alone. It already survives; a deploy replaces the release, not the filesystem around it.
- Already declared, including the `SharedPathSpec` form two sites use to share one database → left alone. The operator's entry wins.

Both the server-app and PHP/Laravel builders get it, so it cannot drift between them.

### Two ways the fix could itself have lost data, closed first

- **Existing state.** `ts_cloud_adopt_shared` already copies the live release's real file into `shared/` the first time a path becomes shared (`-wal`/`-shm` sidecars included). That covers the statushq box as it stands.
- **A site's first deploy.** There is no live release to adopt from, so the empty placeholder would have replaced whatever the artifact shipped — an app shipping a seeded database would come up empty on the deploy that created it. `buildLinkSharedPaths` now seeds a still-empty shared file from the release's own copy. Narrow on purpose: regular non-empty file in the release, shared target still zero bytes (what a placeholder looks like, and what no real SQLite database ever is). It can only put content where there was none.

## #173 — attach mode doesn't check the host, and hides the SSH stderr

**Preflight the host.** Attach mode provisions nothing by design, so `managedServices` in an attached config is a claim about the HOST, not a request. Before anything is built on the owner's services, the deploy probes the box and stops with the incompatibility named:

```
This project declares managedServices.postgres, but 'uptime-status' has no
postgres on 203.0.113.10. Attach mode does not provision services on the
owner's box, so nothing will install it. Point the app at an external service,
or ask the owner of 'uptime-status' to add it to their own config and
re-provision.
```

A service counts as present when its binary is on `PATH` **or** something is listening on its port — either alone, because a stopped service and an engine installed outside pantry are both "the owner has this". A probe that returns no answer never blocks the deploy: preflight, not gate.

**Surface the remote stderr.** `formatSshFailure` already captured and redacted it into `perInstance`, and then both drivers replaced it with a fixed sentence. Callers report `result.error` and nothing else, so the explanation was captured and then dropped — no flag, not even `--verbose`, could print it. `summarizeRemoteFailures` folds the failing instances' output into the error itself (tail-first, since that is where a script names its failure), for SSH and SSM alike.

## Verification

`bun test` — 4068 pass, 0 fail. Both commits typecheck and pass on their own, checked in a separate worktree. Lint clean (the remaining `pickier` warnings are pre-existing, in files this branch does not touch).

New coverage: `sqlite-shared-path.test.ts`, `managed-services-probe.test.ts`, `remote-failure.test.ts`, plus the first-deploy seed guard in `shared-paths.test.ts` and four attach-preflight cases in `compute-deploy.test.ts` (refuses before uploading anything; proceeds when the host provides it; does not block on a silent probe; probes nothing for a project that owns its box).

Docs: `docs/config.md` gains a "State that must survive a deploy" section and an "It cannot install services on the owner's box" section under attach mode; `SiteConfig.sharedPaths` documents the SQLite inference.
