### PR TITLE
feat(consolidation): report an attach's credential radius, and rename a server in place

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -154,6 +154,7 @@ See [Preview environments](/features/preview-environments) for policy, source li
 | `cloud server:list` / `server:create <name>` / `server:destroy <name>` | Manage servers. |
 | `cloud server:ssh <name>` / `server:logs <name>` / `server:monitoring <name>` | Connect / logs / metrics. |
 | `cloud server:deploy <name>` / `server:reboot` / `server:resize <name> <type>` | Deploy / reboot / resize. |
+| `cloud server:rename <name> <new-name> [--apply]` | Rename a server in place. Prints the plan; `--apply` performs it. |
 | `cloud server:recipe <name> <recipe>` | Run a reusable script across servers. |
 | `cloud server:worker:add/list/restart/remove` | Queue workers (Supervisor). |
 | `cloud server:cron:add/list/remove` | Scheduled jobs / cron. |
@@ -163,6 +164,49 @@ See [Preview environments](/features/preview-environments) for policy, source li
 | `cloud server:update <name>` / `server:secure <name>` | OS updates / hardening. |
 
 See [Laravel / Forge-style](/features/laravel) for the `infrastructure.compute` + `sites` config.
+
+### Renaming a server
+
+A name is spelled in four places, and a rename is only done when all four agree:
+the provider record, the local driver state pin
+(`storage/cloud/state/<stack>.json`), the box's own hostname, and the fleet
+inventory record. The state pin is the one that is not cosmetic — a deploy
+REFUSES a pinned server whose live name no longer matches the recorded one, a
+guard against a stale pin sending a database operation to another project's box
+— so renaming at the provider alone quietly invalidates it.
+
+```bash
+cloud server:rename bughq hq-production-server            # plan only
+cloud server:rename bughq hq-production-server --apply    # perform it
+```
+
+Without `--apply` it prints the plan and changes nothing:
+
+```
+server:rename bughq
+  →   Rename the server at the provider
+        bughq → hq-production-server
+  →   Update the recorded name in the local driver state
+        bughq → hq-production-server
+  ok  Set the hostname on the box [already done]
+  →   Rename the fleet inventory record
+        bughq → hq-production-server
+  3 step(s) would run
+  Re-run with --apply to perform it.
+```
+
+Every step asks reality whether it is already done, so a rename that dies
+halfway is resumed by running the same command again — the finished steps skip
+themselves rather than being attempted twice — and a completed rename re-runs as
+`Nothing to do`. A step whose capability is missing is dropped and reported
+under `not covered`: a hand-enrolled server has no provider record, a project
+deploying purely from labels has no state pin, and a box whose host key is not
+pinned cannot be reached to set a hostname (`cloud server:validate` first).
+
+Renaming is reversible by renaming back, so it needs no typed confirmation. It
+is also non-interactive by construction — the plan is data and the authorization
+is a flag — so it runs unattended from CI, and `--json` emits both the plan and
+the outcome. Each step appends to the operation log as it starts and finishes.
 
 ## Databases
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -149,9 +149,32 @@ own provider project cannot be attached at all, because its token cannot see the
 owner's box. Co-hosting trades credential isolation for a shared box; that trade
 is often worth making, but it should be a decision rather than a surprise.
 
-`describeCredentialReach()` and `formatCredentialReach()` report what a given
-token actually reaches, separating the owner's boxes from the ones no one asked
-for, so the radius can be shown before an attach is approved.
+Every attach deploy states this radius before it acts on it, splitting the
+owner's boxes from the ones nobody asked for:
+
+```
+Attaching to 'statushq' shares one provider project, so this deploy's credential
+can write to all 4 server(s) it can see.
+3 of them belong to neither project:
+  bughq: bughq-production-app
+  stacks: stacks-production-app
+  not managed by ts-cloud: some-legacy-box
+A compromised CI run or a mistargeted teardown in this project now reaches those.
+Keep the app in its own provider project instead if that is not acceptable, which
+rules out attaching.
+```
+
+It is reported, never enforced — the trade is frequently worth making, and a
+deploy that started failing on upgrade would teach operators to silence it
+rather than read it. When the reach is exactly the two projects being joined it
+is one quiet line, because a warning that fires every time is a warning nobody
+reads.
+
+The radius comes from the driver (`CloudDriver.listReachableResources()`), not
+from a global assumption about tokens: a provider whose credential can be
+scoped per-resource simply enumerates less, and the same report comes out
+correct without a special case. `describeCredentialReach()` and
+`formatCredentialReach()` are exported for building your own plan output.
 
 ### It cannot install services on the owner's box
 

--- a/packages/core/src/drivers/types.ts
+++ b/packages/core/src/drivers/types.ts
@@ -134,6 +134,37 @@ export interface CloudDriver {
 
   /** Run a shell script on every target (SSM, SSH, etc.) */
   runRemoteDeploy(options: RunRemoteDeployOptions): Promise<RemoteDeployResult>
+
+  /**
+   * Enumerate every resource this driver's credential can see — and therefore,
+   * on providers without per-resource scoping, write to and delete.
+   *
+   * Exists so nothing above the driver has to assume "one all-powerful token"
+   * is the only credential shape. Attaching to another project's box works by
+   * LISTING the provider with the attaching project's own credential, so the
+   * radius is a property of that credential rather than of the config, and only
+   * the driver holding it can report it. A driver whose credential IS narrowly
+   * scoped simply enumerates less, and the same reporting comes out right
+   * without a special case.
+   *
+   * Optional: a driver that cannot enumerate omits it, and callers report no
+   * radius rather than a wrong one.
+   *
+   * @see https://github.com/stacksjs/ts-cloud/issues/169
+   */
+  listReachableResources?(): Promise<ReachableResource[]>
+}
+
+/**
+ * One resource a provider credential can reach, reduced to what attribution
+ * needs: a name to print and the labels that say who owns it.
+ *
+ * Deliberately structural and provider-agnostic — a Hetzner server satisfies it
+ * as-is, and another driver can satisfy it without importing anything.
+ */
+export interface ReachableResource {
+  name: string
+  labels?: Record<string, string>
 }
 
 export interface DeploySiteReleaseOptions {

--- a/packages/ts-cloud/bin/commands/server.ts
+++ b/packages/ts-cloud/bin/commands/server.ts
@@ -2,6 +2,7 @@ import type { CLI } from '@stacksjs/clapp'
 import type { EnvironmentType } from '@ts-cloud/core'
 import type { HetznerResizeCheckpoint } from '../../src/drivers/hetzner/resize-state'
 import type { ServerProvider, ServerRole } from '../../src/fleet'
+import type { ServerRenameEffects } from '../../src/operations/server-rename'
 import { resolveProjectStackName } from '@ts-cloud/core'
 import * as cli from '../../src/utils/cli'
 import { initializeDashboardControlPlane } from '../../src/deploy/dashboard-control-plane'
@@ -20,9 +21,11 @@ import { resolveHetznerServerType } from '../../src/drivers/hetzner/instance-siz
 import { executeHetznerServerResize, planHetznerServerResize } from '../../src/drivers/hetzner/resize'
 import { collectHetznerResizeManifest, prepareHetznerResize, verifyHetznerResize } from '../../src/drivers/hetzner/resize-remote'
 import { acquireResizeLock, readResizeCheckpoint, writeResizeCheckpoint } from '../../src/drivers/hetzner/resize-state'
-import { readDriverState } from '../../src/drivers/hetzner/state'
+import { readDriverState, writeDriverState } from '../../src/drivers/hetzner/state'
 import { usesRpxProxy } from '../../src/drivers/shared/rpx-gateway'
-import { FleetService, FleetStore, SshFleetDriver } from '../../src/fleet'
+import { FleetService, FleetStore, SshFleetDriver, SystemFleetSshTransport } from '../../src/fleet'
+import { applyPlan, formatPlan, resolvePlan } from '../../src/operations/plan'
+import { buildSetHostnameScript, planServerRename } from '../../src/operations/server-rename'
 import { unsupportedCommand } from './capability-command'
 import { loadValidatedConfig } from './shared'
 
@@ -482,6 +485,157 @@ async function runHetznerHostOptimization(name: string, options: OptimizeCommand
   else cli.success(`${server.name} passed full host, rpx route, service, release, and data verification.`)
 }
 
+interface RenameCommandOptions {
+  env?: string
+  apply?: boolean
+  json?: boolean
+}
+
+/**
+ * Wire the four records a rename touches to live effects, plan it, print the
+ * plan, and apply it only when asked.
+ *
+ * Each capability is wired only when it is actually available: a server with no
+ * provider id has no provider record to rename, a project with no state pin for
+ * this server has nothing to repin, and a box whose host key is not pinned
+ * cannot be reached to set a hostname. A missing one drops its step rather than
+ * failing the rename — see `planServerRename`.
+ */
+async function runServerRename(name: string, next: string, options: RenameCommandOptions): Promise<void> {
+  const config = await loadValidatedConfig()
+  const environment = (options.env ?? 'production') as EnvironmentType
+  const stackName = resolveProjectStackName(config, environment)
+
+  await use(async (value) => {
+    const server = find(value, name)
+    const inventory = value.store.list(value.controlPlane.project.id, true)
+
+    // A Hetzner client is only reachable with a token; without one the provider
+    // record simply is not part of this rename, and the plan says so.
+    const hetzner =
+      server.provider === 'hetzner' && server.providerId
+        ? (() => {
+            try {
+              const settings = resolveHetznerSettings(config)
+              return new HetznerClient({ apiToken: resolveHetznerApiToken(settings.apiToken, config) })
+            } catch {
+              return null
+            }
+          })()
+        : null
+    const providerId = server.providerId ? Number(server.providerId) : Number.NaN
+
+    const state = await readDriverState(stackName)
+    // Only repin state that actually points at THIS server. Rewriting a pin for
+    // a different box would be exactly the stale-pin bug the guard exists for.
+    const pinned = state != null && state.serverId === providerId
+
+    const transport = new SystemFleetSshTransport()
+    const reachable = server.trustState === 'pinned'
+
+    const effects: ServerRenameEffects = {
+      takenNames: async () => {
+        const names = inventory.map((item) => item.name)
+        if (hetzner) names.push(...(await hetzner.listServers()).map((item) => item.name))
+        return names
+      },
+      inventoryName: () => value.store.get(server.id)?.name ?? server.name,
+      renameInventory: (value_) => {
+        value.store.update(server.id, { name: value_ })
+      },
+      ...(hetzner && Number.isFinite(providerId)
+        ? {
+            providerName: async () => (await hetzner.getServer(providerId)).name,
+            renameProvider: async (value_: string) => {
+              await hetzner.renameServer(providerId, value_)
+            },
+          }
+        : {}),
+      ...(pinned
+        ? {
+            stateName: async () => (await readDriverState(stackName))?.serverName,
+            writeStateName: async (value_: string) => {
+              const current = await readDriverState(stackName)
+              if (current) await writeDriverState(stackName, { ...current, serverName: value_ })
+            },
+          }
+        : {}),
+      ...(reachable
+        ? {
+            remoteHostname: async () => {
+              const result = await transport.exec(server, 'hostname')
+              return result.code === 0 ? result.stdout.trim() : undefined
+            },
+            setRemoteHostname: async (value_: string) => {
+              const result = await transport.exec(server, buildSetHostnameScript(value_))
+              if (result.code !== 0) throw new Error(result.stderr.trim() || `hostname exited ${result.code}`)
+            },
+          }
+        : {}),
+    }
+
+    const plan = await planServerRename(server.name, next, effects)
+    const resolved = await resolvePlan(plan)
+
+    if (!options.apply) {
+      const skipped = [
+        hetzner ? '' : 'provider record (no provider id or no API token)',
+        pinned ? '' : 'local state pin (none points at this server)',
+        reachable ? '' : 'box hostname (host key is not pinned — run server:validate first)',
+      ].filter(Boolean)
+      if (options.json) {
+        console.log(
+          JSON.stringify(
+            {
+              schemaVersion: 1,
+              operation: plan.operation,
+              target: plan.target,
+              rename: { from: server.name, to: next },
+              notCovered: skipped,
+              steps: resolved.map((item) => ({
+                id: item.step.id,
+                title: item.step.title,
+                state: item.state,
+                change: item.step.change,
+                reason: item.reason,
+              })),
+            },
+            null,
+            2,
+          ),
+        )
+        return
+      }
+      for (const line of formatPlan(plan, resolved)) console.log(line)
+      for (const item of skipped) console.log(`  not covered: ${item}`)
+      console.log('  Re-run with --apply to perform it.')
+      return
+    }
+
+    const outcome = await applyPlan(plan, resolved, {
+      log: (message) => cli.info(message),
+      audit: (event) =>
+        value.controlPlane.store.appendEvent({
+          projectId: value.controlPlane.project.id,
+          resourceId: server.resourceId,
+          type: `${event.operation}.${event.step}.${event.state}`,
+          level: event.state === 'failed' ? 'error' : 'info',
+          payload: { target: event.target, renameTo: next, ...(event.error ? { error: event.error } : {}) },
+        }),
+    })
+
+    if (options.json) console.log(JSON.stringify({ schemaVersion: 1, outcome }, null, 2))
+    if (!outcome.success) {
+      const failed = outcome.steps.find((step) => step.state === 'failed')
+      throw new Error(
+        `${plan.operation} stopped at '${failed?.title}': ${failed?.error}. `
+        + 'Earlier steps stayed applied; re-run the same command to continue from here.',
+      )
+    }
+    if (!options.json) cli.success(`Renamed ${server.name} to ${next}.`)
+  })
+}
+
 export function registerServerCommands(app: CLI): void {
   app
     .command('capabilities [server]', 'Show provider and target operation support')
@@ -669,6 +823,18 @@ export function registerServerCommands(app: CLI): void {
             )
           else cli.success(`Bootstrap queued: ${result.operation?.id}`)
         })
+      } catch (error) {
+        fail(error)
+      }
+    })
+  app
+    .command('server:rename <name> <new-name>', 'Rename a server in place, without recreating it')
+    .option('--env <environment>', 'Deployment environment', { default: 'production' })
+    .option('--apply', 'Perform the reviewed rename plan')
+    .option('--json', 'Print structured JSON')
+    .action(async (name: string, newName: string, options: RenameCommandOptions) => {
+      try {
+        await runServerRename(name, newName, options)
       } catch (error) {
         fail(error)
       }

--- a/packages/ts-cloud/src/deploy/attach-credentials.ts
+++ b/packages/ts-cloud/src/deploy/attach-credentials.ts
@@ -1,3 +1,4 @@
+import type { ReachableResource } from '@ts-cloud/core'
 import { TS_CLOUD_LABEL_PREFIX } from '../drivers/hetzner/instance-sizes'
 
 /**
@@ -28,15 +29,10 @@ import { TS_CLOUD_LABEL_PREFIX } from '../drivers/hetzner/instance-sizes'
 const PROJECT_LABEL = `${TS_CLOUD_LABEL_PREFIX}/project`
 
 /**
- * The minimum a driver has to produce for a server to be attributed.
- *
- * Structural rather than a provider type so a Hetzner server satisfies it as-is
- * and another driver can satisfy it without importing anything.
+ * The minimum a driver has to produce for a server to be attributed — the shape
+ * `CloudDriver.listReachableResources()` returns.
  */
-export interface ReachableServer {
-  name: string
-  labels?: Record<string, string>
-}
+export type ReachableServer = ReachableResource
 
 export interface CredentialReach {
   /** Every server the credential enumerated. */

--- a/packages/ts-cloud/src/drivers/hetzner/driver.ts
+++ b/packages/ts-cloud/src/drivers/hetzner/driver.ts
@@ -1,4 +1,4 @@
-import type { CloudDriver, ComputeProxyConfig, ComputeStackOutputs, ComputeTarget, FindComputeTargetsOptions, ProvisionComputeOptions, RemoteDeployResult, RunRemoteDeployOptions, SiteConfig, UploadReleaseOptions, UploadReleaseResult } from '@ts-cloud/core'
+import type { CloudDriver, ComputeProxyConfig, ComputeStackOutputs, ComputeTarget, FindComputeTargetsOptions, ProvisionComputeOptions, ReachableResource, RemoteDeployResult, RunRemoteDeployOptions, SiteConfig, UploadReleaseOptions, UploadReleaseResult } from '@ts-cloud/core'
 import type { RpxLbAppBox } from '../shared/rpx-gateway'
 import type { HetznerFirewall, HetznerFirewallRule, HetznerServer } from './client'
 import type { HetznerDriverState } from './state'
@@ -1237,6 +1237,17 @@ export class HetznerDriver implements CloudDriver {
     await writeDriverState(stackName, state)
 
     return this.outputsFromState(state)
+  }
+
+  /**
+   * Every server this token can see. On Hetzner that is every server in the
+   * provider project, because a Cloud API token is project-scoped with Read or
+   * Read & Write and no per-resource scoping — so "can see" and "can delete"
+   * are the same set, and the count is the honest blast radius.
+   */
+  async listReachableResources(): Promise<ReachableResource[]> {
+    const servers = await this.client.listServers()
+    return servers.map((server) => ({ name: server.name, labels: server.labels }))
   }
 
   async runRemoteDeploy(options: RunRemoteDeployOptions): Promise<RemoteDeployResult> {

--- a/packages/ts-cloud/src/drivers/shared/compute-deploy.ts
+++ b/packages/ts-cloud/src/drivers/shared/compute-deploy.ts
@@ -4,6 +4,7 @@ import { copyFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { hasManagementDashboardSite, resolveAppDatabase, resolveProjectStackName } from '@ts-cloud/core'
+import { describeCredentialReach, formatCredentialReach, unrelatedReachCount } from '../../deploy/attach-credentials'
 import { buildManagementDashboardArtifact, ensureManagementDashboard, managementDashboardSiteNames } from '../../deploy/management-dashboard'
 import { isPhpSite, resolveSiteKind, siteInstallBase } from '../../deploy/site-target'
 import { buildSiteServicesScript, siteHasServices } from './app-services'
@@ -495,6 +496,53 @@ async function reconcileManagementDashboardServices(
 }
 
 /**
+ * Attach mode: report what this deploy's credential can actually reach.
+ *
+ * Attaching resolves the owner's box by LISTING the provider with the ATTACHING
+ * project's own credential. That listing is the whole mechanism, and it has a
+ * consequence the config never states — the owner's box has to be visible to
+ * this credential, so both projects share one provider project, and on a
+ * provider without per-resource scoping that means write over every server in
+ * it. Three apps that each owned one box become three pipelines that each reach
+ * all three.
+ *
+ * Reported, never enforced. The trade is frequently worth making, and a deploy
+ * that started failing on upgrade would teach operators to silence it rather
+ * than to read it. The quiet case stays quiet: when the reach is exactly the two
+ * projects being joined, this is one info line, because a warning that fires
+ * every time is a warning nobody reads.
+ *
+ * @see https://github.com/stacksjs/ts-cloud/issues/169
+ */
+async function reportAttachCredentialReach(
+  driver: CloudDriver,
+  options: DeployAllSitesOptions,
+  logger: ComputeDeployLogger,
+): Promise<void> {
+  const { config } = options
+  const ownerSlug = config.cloud?.attachTo
+  // A driver that cannot enumerate reports no radius rather than a wrong one.
+  if (!ownerSlug || !driver.listReachableResources) return
+
+  let resources
+  try {
+    resources = await driver.listReachableResources()
+  } catch (error) {
+    // Never fail a deploy over the advisory. A token that cannot list is a
+    // problem the real work reports far better than this can.
+    logger.warn(`Could not determine this credential's reach: ${error instanceof Error ? error.message : String(error)}`)
+    return
+  }
+
+  const reach = describeCredentialReach(resources, { ownerSlug, selfSlug: config.project.slug })
+  const surprising = unrelatedReachCount(reach) > 0
+  for (const line of formatCredentialReach(reach, { ownerSlug, selfSlug: config.project.slug })) {
+    if (surprising) logger.warn(line)
+    else logger.info(line)
+  }
+}
+
+/**
  * Attach mode preflight: does the owner's box actually provide the on-box
  * services this project declares?
  *
@@ -712,6 +760,10 @@ export async function deployAllComputeSites(options: DeployAllSitesOptions): Pro
   // written. Returning here left such a project silently untouched — the deploy
   // ran green and the box kept a hand-maintained fragment.
   if (deployable.length === 0) return reloadRpxGateway(options)
+
+  // Attach mode (`cloud.attachTo`): state the credential radius this attach
+  // implies before it is acted on. Advisory — see the function.
+  await reportAttachCredentialReach(driver, options, logger)
 
   // Attach mode (`cloud.attachTo`): before anything is built ON the owner's
   // services, confirm the owner's box actually runs them.

--- a/packages/ts-cloud/src/operations/plan.test.ts
+++ b/packages/ts-cloud/src/operations/plan.test.ts
@@ -1,0 +1,127 @@
+import type { OperationPlan, OperationStep } from './plan'
+import { describe, expect, it } from 'bun:test'
+import { applyPlan, formatPlan, pendingSteps, planIsDestructive, resolvePlan } from './plan'
+
+function step(overrides: Partial<OperationStep> & { id: string }): OperationStep {
+  return {
+    title: `step ${overrides.id}`,
+    satisfied: async () => false,
+    apply: async () => {},
+    ...overrides,
+  }
+}
+
+const plan = (steps: OperationStep[]): OperationPlan => ({ operation: 'server:rename', target: 'bughq', steps })
+
+describe('resolvePlan', () => {
+  it('separates what would run from what is already done', async () => {
+    const resolved = await resolvePlan(
+      plan([step({ id: 'a', satisfied: async () => true }), step({ id: 'b' })]),
+    )
+    expect(resolved.map(item => item.state)).toEqual(['satisfied', 'pending'])
+    expect(pendingSteps(resolved).map(item => item.step.id)).toEqual(['b'])
+  })
+
+  /**
+   * Not being able to check is a reason to run the step and say so, not a reason
+   * to refuse the operator a plan.
+   */
+  it('marks a step whose check throws as unknown rather than failing the plan', async () => {
+    const resolved = await resolvePlan(
+      plan([step({ id: 'a', satisfied: async () => { throw new Error('token expired') } })]),
+    )
+    expect(resolved[0].state).toBe('unknown')
+    expect(resolved[0].reason).toBe('token expired')
+    // Unknown is never skipped.
+    expect(pendingSteps(resolved)).toHaveLength(1)
+  })
+})
+
+describe('formatPlan', () => {
+  it('shows each change as from → to, in declaration order', async () => {
+    const p = plan([
+      step({ id: 'provider', title: 'Rename at the provider', change: { from: 'bughq', to: 'hq-production' } }),
+      step({ id: 'inventory', title: 'Rename the record', satisfied: async () => true }),
+    ])
+    const lines = formatPlan(p, await resolvePlan(p)).join('\n')
+    expect(lines).toContain('server:rename bughq')
+    expect(lines).toContain('→   Rename at the provider')
+    expect(lines).toContain('bughq → hq-production')
+    expect(lines).toContain('ok  Rename the record [already done]')
+    expect(lines).toContain('1 step(s) would run')
+  })
+
+  it('says so plainly when a fully-applied operation is re-run', async () => {
+    const p = plan([step({ id: 'a', satisfied: async () => true })])
+    expect(formatPlan(p, await resolvePlan(p)).join('\n')).toContain('Nothing to do')
+  })
+
+  it('names the confirmation an irreversible step needs', async () => {
+    const p = plan([step({ id: 'delete', title: 'Delete the drained server', destructive: true })])
+    expect(formatPlan(p, await resolvePlan(p)).join('\n')).toContain('1 irreversible — re-run with --confirm bughq')
+  })
+
+  it('does not demand confirmation for an irreversible step that is already done', async () => {
+    const p = plan([step({ id: 'delete', destructive: true, satisfied: async () => true })])
+    const resolved = await resolvePlan(p)
+    expect(planIsDestructive(resolved)).toBe(false)
+  })
+})
+
+describe('applyPlan', () => {
+  it('runs pending steps and skips satisfied ones', async () => {
+    const ran: string[] = []
+    const p = plan([
+      step({ id: 'a', satisfied: async () => true, apply: async () => { ran.push('a') } }),
+      step({ id: 'b', apply: async () => { ran.push('b') } }),
+    ])
+    const outcome = await applyPlan(p, await resolvePlan(p))
+    expect(ran).toEqual(['b'])
+    expect(outcome.success).toBe(true)
+    expect(outcome.steps.map(s => s.state)).toEqual(['skipped', 'applied'])
+  })
+
+  /**
+   * A topology change half-applied and reported is recoverable; one silently
+   * rolled back to a state nobody has verified is not.
+   */
+  it('stops at the first failure and leaves earlier steps applied', async () => {
+    const ran: string[] = []
+    const p = plan([
+      step({ id: 'a', apply: async () => { ran.push('a') } }),
+      step({ id: 'b', apply: async () => { throw new Error('provider said no') } }),
+      step({ id: 'c', apply: async () => { ran.push('c') } }),
+    ])
+    const outcome = await applyPlan(p, await resolvePlan(p))
+    expect(ran).toEqual(['a'])
+    expect(outcome.success).toBe(false)
+    expect(outcome.steps.map(s => s.state)).toEqual(['applied', 'failed'])
+    expect(outcome.steps[1].error).toBe('provider said no')
+  })
+
+  it('re-runs as a clean no-op once everything is satisfied', async () => {
+    let applied = false
+    const p = plan([step({ id: 'a', satisfied: async () => applied, apply: async () => { applied = true } })])
+    expect((await applyPlan(p, await resolvePlan(p))).steps[0].state).toBe('applied')
+    expect((await applyPlan(p, await resolvePlan(p))).steps[0].state).toBe('skipped')
+  })
+
+  it('refuses an irreversible step without the exact target as confirmation', async () => {
+    const p = plan([step({ id: 'delete', destructive: true })])
+    const resolved = await resolvePlan(p)
+    await expect(applyPlan(p, resolved)).rejects.toThrow('--confirm bughq')
+    await expect(applyPlan(p, resolved, { confirm: 'wrong' })).rejects.toThrow('--confirm bughq')
+    expect((await applyPlan(p, resolved, { confirm: 'bughq' })).success).toBe(true)
+  })
+
+  /**
+   * The start is recorded before the step runs, because a run that dies mid-step
+   * is exactly the case an operator is trying to reconstruct afterwards.
+   */
+  it('audits each step starting and finishing', async () => {
+    const events: string[] = []
+    const p = plan([step({ id: 'a' }), step({ id: 'b', apply: async () => { throw new Error('boom') } })])
+    await applyPlan(p, await resolvePlan(p), { audit: e => events.push(`${e.step}:${e.state}`) })
+    expect(events).toEqual(['a:started', 'a:applied', 'b:started', 'b:failed'])
+  })
+})

--- a/packages/ts-cloud/src/operations/plan.ts
+++ b/packages/ts-cloud/src/operations/plan.ts
@@ -1,0 +1,219 @@
+/**
+ * Plan-then-apply scaffolding for fleet operations that change live topology.
+ *
+ * Consolidating servers — moving an app to another box, attaching one as a site,
+ * renaming a box — is a routine cleanup that is currently an afternoon of SSH.
+ * What makes it an afternoon is not the individual steps, which are small; it is
+ * that a half-finished one leaves no way to tell what already happened. So every
+ * such operation is expressed the same way here:
+ *
+ * - **Plan first.** A step says what it would change (`from → to`) before
+ *   anything is touched, and prints the same way every run so a plan can be
+ *   diffed.
+ * - **Idempotent and resumable.** Resumability comes from `satisfied()`, which
+ *   asks REALITY whether the step's intent already holds — not from a checkpoint
+ *   file, which can disagree with the world after a crash. Re-running an
+ *   operation that died halfway continues rather than starting over or
+ *   double-applying, and a fully-applied operation re-runs as a clean no-op.
+ * - **Typed confirmation for the destructive half.** Irreversible steps are
+ *   marked, counted separately, and gated on the operator typing the target's
+ *   exact name — separately from the operation itself.
+ * - **Non-interactive.** Nothing here reads stdin: a plan is data, the
+ *   confirmation is a flag, so the whole sequence is drivable from CI.
+ * - **Audited.** Each step reports through {@link ApplyPlanOptions.audit} as it
+ *   starts and finishes, so the operation log carries what actually ran.
+ *
+ * @see https://github.com/stacksjs/ts-cloud/issues/167
+ */
+
+/** A value a step changes, rendered in the plan as `from → to`. */
+export interface StepChange {
+  from: string
+  to: string
+}
+
+export interface OperationStep {
+  /** Stable across runs — this is what an audit log and a resumed run key on. */
+  id: string
+  /** One line, imperative: "Rename the Hetzner server". */
+  title: string
+  /** What the step changes. Omitted for steps that only verify. */
+  change?: StepChange
+  /**
+   * Irreversible. Marked in the plan and gated on typed confirmation, because
+   * "delete the drained source server" and "move an app" deserve different
+   * levels of ceremony even inside one operation.
+   */
+  destructive?: boolean
+  /**
+   * Does reality ALREADY match this step's intent? This is what makes an
+   * operation resumable: a step that is satisfied is skipped, so a run that died
+   * halfway picks up where it stopped without the caller tracking progress.
+   *
+   * Must not mutate anything, and must tolerate a partially-applied world.
+   */
+  satisfied: () => Promise<boolean>
+  /** Perform the change. Only called when `satisfied()` returned false. */
+  apply: () => Promise<void>
+}
+
+export interface OperationPlan {
+  /** Stable operation name, e.g. `server:rename`. */
+  operation: string
+  /** What is being operated on, and what a destructive step's confirmation must match. */
+  target: string
+  steps: OperationStep[]
+}
+
+/** A step paired with what resolving it against the live world found. */
+export interface ResolvedStep {
+  step: OperationStep
+  /** `satisfied` — nothing to do; `pending` — would run; `unknown` — could not tell. */
+  state: 'satisfied' | 'pending' | 'unknown'
+  /** Why the state is `unknown`. A step that cannot be checked is never skipped. */
+  reason?: string
+}
+
+/**
+ * Ask every step whether it is already satisfied.
+ *
+ * A `satisfied()` that THROWS resolves to `unknown` rather than failing the
+ * plan: not being able to check is a reason to run the step and to say so, not a
+ * reason to refuse to show the operator a plan. Steps are resolved in order,
+ * because a later step's check may depend on an earlier one's subject existing.
+ */
+export async function resolvePlan(plan: OperationPlan): Promise<ResolvedStep[]> {
+  const resolved: ResolvedStep[] = []
+  for (const step of plan.steps) {
+    try {
+      resolved.push({ step, state: (await step.satisfied()) ? 'satisfied' : 'pending' })
+    } catch (error) {
+      resolved.push({ step, state: 'unknown', reason: error instanceof Error ? error.message : String(error) })
+    }
+  }
+  return resolved
+}
+
+/** Steps that would actually run — pending, plus the ones that could not be checked. */
+export function pendingSteps(resolved: readonly ResolvedStep[]): ResolvedStep[] {
+  return resolved.filter(item => item.state !== 'satisfied')
+}
+
+/** Do any steps that would run make an irreversible change? */
+export function planIsDestructive(resolved: readonly ResolvedStep[]): boolean {
+  return pendingSteps(resolved).some(item => item.step.destructive === true)
+}
+
+/**
+ * The plan as lines, ready to print.
+ *
+ * Lines rather than printed output so the caller owns the stream and this stays
+ * testable, and in declaration order so two runs of an unchanged plan produce an
+ * identical diff.
+ */
+export function formatPlan(plan: OperationPlan, resolved: readonly ResolvedStep[]): string[] {
+  const pending = pendingSteps(resolved)
+  const lines = [`${plan.operation} ${plan.target}`]
+
+  if (pending.length === 0) {
+    lines.push('  Nothing to do — every step is already satisfied.')
+    return lines
+  }
+
+  for (const { step, state, reason } of resolved) {
+    const mark = state === 'satisfied' ? 'ok  ' : state === 'unknown' ? '?   ' : '→   '
+    const flags = [
+      step.destructive ? 'DESTRUCTIVE' : '',
+      state === 'satisfied' ? 'already done' : '',
+    ].filter(Boolean)
+    lines.push(`  ${mark}${step.title}${flags.length > 0 ? ` [${flags.join(', ')}]` : ''}`)
+    if (step.change) lines.push(`        ${step.change.from} → ${step.change.to}`)
+    if (reason) lines.push(`        could not check: ${reason}`)
+  }
+
+  const destructive = pending.filter(item => item.step.destructive).length
+  lines.push(
+    `  ${pending.length} step(s) would run`
+    + (destructive > 0 ? `, ${destructive} irreversible — re-run with --confirm ${plan.target}` : ''),
+  )
+  return lines
+}
+
+export interface StepOutcome {
+  id: string
+  title: string
+  /** `applied` — it ran; `skipped` — already satisfied; `failed` — it threw. */
+  state: 'applied' | 'skipped' | 'failed'
+  error?: string
+}
+
+export interface OperationOutcome {
+  operation: string
+  target: string
+  steps: StepOutcome[]
+  /** False when any step failed. The steps before it stay applied — see below. */
+  success: boolean
+}
+
+export interface ApplyPlanOptions {
+  /** Progress, one line per step. */
+  log?: (message: string) => void
+  /**
+   * Append to the operation log. Called as each step starts and finishes, so a
+   * run that dies mid-step still leaves the start recorded — which is exactly
+   * the case an operator is trying to reconstruct afterwards.
+   */
+  audit?: (event: { operation: string, target: string, step: string, state: 'started' | StepOutcome['state'], error?: string }) => void
+  /**
+   * Exact target name, required before any irreversible step runs. A plan with
+   * no destructive pending step ignores this.
+   */
+  confirm?: string
+}
+
+/**
+ * Run the pending steps in order.
+ *
+ * Stops at the first failure and leaves the earlier steps applied, deliberately:
+ * a topology change half-applied and reported is recoverable — re-run it, the
+ * satisfied steps skip themselves — while one silently rolled back to a state
+ * nobody has verified is not.
+ */
+export async function applyPlan(
+  plan: OperationPlan,
+  resolved: readonly ResolvedStep[],
+  options: ApplyPlanOptions = {},
+): Promise<OperationOutcome> {
+  const outcome: OperationOutcome = { operation: plan.operation, target: plan.target, steps: [], success: true }
+
+  if (planIsDestructive(resolved) && options.confirm !== plan.target) {
+    throw new Error(
+      `${plan.operation} includes an irreversible step. Re-run with --confirm ${plan.target} to authorize it.`,
+    )
+  }
+
+  for (const { step, state } of resolved) {
+    if (state === 'satisfied') {
+      outcome.steps.push({ id: step.id, title: step.title, state: 'skipped' })
+      options.log?.(`skip  ${step.title} (already done)`)
+      continue
+    }
+
+    options.audit?.({ operation: plan.operation, target: plan.target, step: step.id, state: 'started' })
+    try {
+      await step.apply()
+      outcome.steps.push({ id: step.id, title: step.title, state: 'applied' })
+      options.log?.(`done  ${step.title}`)
+      options.audit?.({ operation: plan.operation, target: plan.target, step: step.id, state: 'applied' })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      outcome.steps.push({ id: step.id, title: step.title, state: 'failed', error: message })
+      outcome.success = false
+      options.log?.(`FAIL  ${step.title}: ${message}`)
+      options.audit?.({ operation: plan.operation, target: plan.target, step: step.id, state: 'failed', error: message })
+      return outcome
+    }
+  }
+
+  return outcome
+}

--- a/packages/ts-cloud/src/operations/server-rename.test.ts
+++ b/packages/ts-cloud/src/operations/server-rename.test.ts
@@ -1,0 +1,154 @@
+import type { ServerRenameEffects } from './server-rename'
+import { describe, expect, it } from 'bun:test'
+import { applyPlan, formatPlan, resolvePlan } from './plan'
+import { buildSetHostnameScript, planServerRename, validateServerName } from './server-rename'
+
+/** A fully-capable server: provider record, state pin, reachable box, inventory. */
+function world(name = 'bughq') {
+  const state = { provider: name, pin: name, hostname: name, inventory: name, taken: [name, 'statushq'] }
+  const effects: ServerRenameEffects = {
+    takenNames: async () => state.taken,
+    providerName: async () => state.provider,
+    renameProvider: async (next) => { state.provider = next },
+    stateName: async () => state.pin,
+    writeStateName: async (next) => { state.pin = next },
+    remoteHostname: async () => state.hostname,
+    setRemoteHostname: async (next) => { state.hostname = next },
+    inventoryName: () => state.inventory,
+    renameInventory: (next) => { state.inventory = next },
+  }
+  return { state, effects }
+}
+
+describe('validateServerName', () => {
+  it('accepts a hostname', () => {
+    expect(() => validateServerName('hq-production-server')).not.toThrow()
+    expect(() => validateServerName('hq.example.com')).not.toThrow()
+  })
+
+  it('refuses what a provider or /etc/hostname would refuse', () => {
+    expect(() => validateServerName('')).toThrow('cannot be empty')
+    expect(() => validateServerName('-leading')).toThrow('not a valid hostname label')
+    expect(() => validateServerName('trailing-')).toThrow('not a valid hostname label')
+    expect(() => validateServerName('under_score')).toThrow('not a valid hostname label')
+    expect(() => validateServerName('a..b')).toThrow('empty label')
+    expect(() => validateServerName(`${'a'.repeat(64)}.com`)).toThrow('63 characters')
+  })
+})
+
+describe('planServerRename preconditions', () => {
+  it('refuses a name another server already holds', async () => {
+    await expect(planServerRename('bughq', 'statushq', world().effects)).rejects.toThrow('already taken')
+  })
+
+  it('refuses a no-op rename', async () => {
+    await expect(planServerRename('bughq', 'bughq', world().effects)).rejects.toThrow('already named that')
+  })
+
+  /**
+   * A precondition is not a unit of work: an illegal name must fail before the
+   * plan exists, not on its first step with the provider already renamed.
+   */
+  it('refuses an illegal name before building any step', async () => {
+    await expect(planServerRename('bughq', 'not_a_hostname', world().effects)).rejects.toThrow('valid hostname')
+  })
+})
+
+describe('planServerRename', () => {
+  it('covers all four records, provider before the state pin', async () => {
+    const plan = await planServerRename('bughq', 'hq-production-server', world().effects)
+    expect(plan.steps.map(step => step.id)).toEqual(['provider', 'state-pin', 'hostname', 'inventory'])
+  })
+
+  it('renames every record when applied', async () => {
+    const { state, effects } = world()
+    const plan = await planServerRename('bughq', 'hq-production-server', effects)
+    const outcome = await applyPlan(plan, await resolvePlan(plan))
+    expect(outcome.success).toBe(true)
+    expect(state).toMatchObject({
+      provider: 'hq-production-server',
+      pin: 'hq-production-server',
+      hostname: 'hq-production-server',
+      inventory: 'hq-production-server',
+    })
+  })
+
+  it('needs no confirmation — a rename is undone by renaming back', async () => {
+    const plan = await planServerRename('bughq', 'hq-production-server', world().effects)
+    expect(plan.steps.some(step => step.destructive)).toBe(false)
+  })
+
+  /**
+   * The point of resumability: a rename that died after the provider call is
+   * re-run, and the provider step skips itself instead of being attempted again.
+   */
+  it('resumes a half-finished rename without redoing the finished half', async () => {
+    const { state, effects } = world()
+    state.provider = 'hq-production-server'
+    let providerCalls = 0
+    const plan = await planServerRename('bughq', 'hq-production-server', {
+      ...effects,
+      renameProvider: async (next) => { providerCalls++; state.provider = next },
+    })
+    const resolved = await resolvePlan(plan)
+    expect(resolved[0].state).toBe('satisfied')
+    const outcome = await applyPlan(plan, resolved)
+    expect(providerCalls).toBe(0)
+    expect(outcome.steps[0].state).toBe('skipped')
+    expect(state.inventory).toBe('hq-production-server')
+  })
+
+  it('is a clean no-op when re-run after finishing', async () => {
+    const { effects } = world()
+    const plan = await planServerRename('bughq', 'hq-production-server', effects)
+    await applyPlan(plan, await resolvePlan(plan))
+    const again = await resolvePlan(plan)
+    expect(formatPlan(plan, again).join('\n')).toContain('Nothing to do')
+  })
+
+  /**
+   * A server enrolled by hand has no provider record, a project deploying purely
+   * from labels has no pin, and an unpinned host key means no SSH. Each missing
+   * capability drops its step rather than failing the rename.
+   */
+  it('drops the steps whose capability is missing', async () => {
+    const { state } = world()
+    const plan = await planServerRename('bughq', 'hq-production-server', {
+      takenNames: async () => state.taken,
+      inventoryName: () => state.inventory,
+      renameInventory: (next) => { state.inventory = next },
+    })
+    expect(plan.steps.map(step => step.id)).toEqual(['inventory'])
+    expect((await applyPlan(plan, await resolvePlan(plan))).success).toBe(true)
+    expect(state.inventory).toBe('hq-production-server')
+  })
+
+  /** A project with no pin at all must not gain one it never asked for. */
+  it('treats an absent state pin as nothing to update', async () => {
+    const { state, effects } = world()
+    let wrote = false
+    const plan = await planServerRename('bughq', 'hq-production-server', {
+      ...effects,
+      stateName: async () => undefined,
+      writeStateName: async () => { wrote = true },
+    })
+    await applyPlan(plan, await resolvePlan(plan))
+    expect(wrote).toBe(false)
+    expect(state.inventory).toBe('hq-production-server')
+  })
+})
+
+describe('buildSetHostnameScript', () => {
+  it('sets the hostname persistently with a fallback', () => {
+    const script = buildSetHostnameScript('hq-production-server')
+    expect(script).toContain("hostnamectl set-hostname 'hq-production-server'")
+    expect(script).toContain('/etc/hostname')
+  })
+
+  /** Two 127.0.1.1 lines would leave the box resolving its own name two ways. */
+  it('replaces the existing 127.0.1.1 line rather than appending a second', () => {
+    const script = buildSetHostnameScript('hq-production-server')
+    expect(script).toContain('s/^127\\.0\\.1\\.1.*/127.0.1.1\\thq-production-server/')
+    expect(script).toContain('if grep -q "127.0.1.1" /etc/hosts; then')
+  })
+})

--- a/packages/ts-cloud/src/operations/server-rename.ts
+++ b/packages/ts-cloud/src/operations/server-rename.ts
@@ -1,0 +1,187 @@
+/**
+ * Rename a server in place.
+ *
+ * Renaming is purely an identity change, and today it implies destroy-and-
+ * recreate — which is not an acceptable cost for a naming-convention fix. It is
+ * the smallest of the consolidation operations and the one with no data to move:
+ * four records that all spell the same name, kept in step.
+ *
+ * The four, and why each matters:
+ *
+ * 1. **The provider record.** What the console shows and what a human greps for.
+ * 2. **The local driver state pin** (`storage/cloud/state/<stack>.json`). This
+ *    one is not cosmetic. `findComputeTargets` REJECTS a pinned server whose
+ *    live name no longer matches the recorded one — a deliberate guard against
+ *    a stale pin sending a database operation to another project's box — so a
+ *    provider-side rename that does not update the pin quietly invalidates it.
+ * 3. **The box's hostname.** What shells, logs, and the box's own reports say.
+ * 4. **The fleet inventory record.** What every `server:*` command addresses.
+ *
+ * Ordering is chosen for the failure in between: the provider is renamed BEFORE
+ * the pin is rewritten, so a crash between them leaves the pin stale (deploys
+ * fall back to label matching and keep working) rather than pointing at a name
+ * that does not exist yet. Every step re-derives its own state, so the fix for a
+ * half-finished rename is to run it again.
+ *
+ * Nothing here is destructive: a rename is undone by renaming back, and putting
+ * typed-confirmation ceremony on a reversible operation only teaches people to
+ * type confirmations without reading them.
+ *
+ * @see https://github.com/stacksjs/ts-cloud/issues/167
+ */
+import type { OperationPlan, OperationStep } from './plan'
+
+/**
+ * The side effects a rename needs, injected so the operation is testable without
+ * a provider, an SSH host, or a control-plane database — and so a second driver
+ * can supply its own without this module knowing about it.
+ *
+ * The optional members are genuinely optional: a server enrolled by hand has no
+ * provider record to rename, a project deploying purely from labels has no state
+ * pin, and a box whose host key is not pinned cannot be reached to set a
+ * hostname. Each missing capability drops its step from the plan rather than
+ * failing the operation, and the plan says which ones it left out.
+ */
+export interface ServerRenameEffects {
+  /** Every name already taken — provider project and inventory both. */
+  takenNames: () => Promise<string[]>
+  /** Live provider-side name. */
+  providerName?: () => Promise<string | undefined>
+  renameProvider?: (next: string) => Promise<void>
+  /** Name recorded in the local driver state pin. */
+  stateName?: () => Promise<string | undefined>
+  writeStateName?: (next: string) => Promise<void>
+  /** Hostname reported by the box itself. */
+  remoteHostname?: () => Promise<string | undefined>
+  setRemoteHostname?: (next: string) => Promise<void>
+  /** Name on the fleet inventory record. */
+  inventoryName: () => string
+  renameInventory: (next: string) => Promise<void> | void
+}
+
+/**
+ * A server name has to be a valid hostname, because it becomes one: providers
+ * reject anything else, and the box's own `hostname` is set from it.
+ *
+ * RFC 1123 labels — letters, digits and hyphens, not starting or ending with a
+ * hyphen, at most 63 characters each — joined by dots. Checked up front so a
+ * rename fails before it has touched anything, rather than halfway through with
+ * the provider renamed and the box not.
+ */
+export function validateServerName(name: string): void {
+  if (name.length === 0) throw new Error('A server name cannot be empty.')
+  if (name.length > 253) throw new Error(`'${name}' is longer than the 253 characters a hostname allows.`)
+  for (const label of name.split('.')) {
+    if (label.length === 0) throw new Error(`'${name}' has an empty label — a hostname cannot contain '..'.`)
+    if (label.length > 63) throw new Error(`'${label}' is longer than the 63 characters a hostname label allows.`)
+    if (!/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i.test(label))
+      throw new Error(
+        `'${label}' is not a valid hostname label. Use letters, digits and hyphens, not starting or ending with a hyphen.`,
+      )
+  }
+}
+
+/**
+ * Build the plan that renames `current` to `next`.
+ *
+ * Async because the preconditions — a legal name, and one nobody else holds —
+ * are checked here rather than becoming steps. A precondition is not a unit of
+ * work; making it one would let a plan print as if it were runnable and then
+ * fail on its first step.
+ */
+export async function planServerRename(
+  current: string,
+  next: string,
+  effects: ServerRenameEffects,
+): Promise<OperationPlan> {
+  validateServerName(next)
+
+  if (current === next) throw new Error(`'${current}' is already named that.`)
+
+  const taken = await effects.takenNames()
+  if (taken.some(name => name === next && name !== current))
+    throw new Error(`'${next}' is already taken. Server names have to be unique within a provider project.`)
+
+  const steps: OperationStep[] = []
+
+  // 1. The provider record first: a crash after this leaves the state pin stale,
+  //    which degrades to label matching, rather than pinned to a name that does
+  //    not exist yet.
+  if (effects.providerName && effects.renameProvider) {
+    const { providerName, renameProvider } = effects
+    steps.push({
+      id: 'provider',
+      title: 'Rename the server at the provider',
+      change: { from: current, to: next },
+      satisfied: async () => (await providerName()) === next,
+      apply: () => renameProvider(next),
+    })
+  }
+
+  // 2. The state pin, immediately after — see the note above findComputeTargets.
+  if (effects.stateName && effects.writeStateName) {
+    const { stateName, writeStateName } = effects
+    steps.push({
+      id: 'state-pin',
+      title: 'Update the recorded name in the local driver state',
+      change: { from: current, to: next },
+      // A project with no pin at all has nothing to update; treat it as done
+      // rather than writing a pin the deploy never asked for.
+      satisfied: async () => {
+        const recorded = await stateName()
+        return recorded === undefined || recorded === next
+      },
+      apply: () => writeStateName(next),
+    })
+  }
+
+  // 3. The box's own hostname. Last of the remote changes because it is the only
+  //    cosmetic one — a box whose hostname lags is confusing, not broken.
+  if (effects.remoteHostname && effects.setRemoteHostname) {
+    const { remoteHostname, setRemoteHostname } = effects
+    steps.push({
+      id: 'hostname',
+      title: 'Set the hostname on the box',
+      change: { from: current, to: next },
+      satisfied: async () => (await remoteHostname()) === next,
+      apply: () => setRemoteHostname(next),
+    })
+  }
+
+  // 4. The inventory record last: it is what every `server:*` command addresses,
+  //    so renaming it first would leave the operator addressing a server whose
+  //    other three records still answer to the old name.
+  steps.push({
+    id: 'inventory',
+    title: 'Rename the fleet inventory record',
+    change: { from: current, to: next },
+    satisfied: async () => effects.inventoryName() === next,
+    apply: async () => {
+      await effects.renameInventory(next)
+    },
+  })
+
+  return { operation: 'server:rename', target: current, steps }
+}
+
+/**
+ * Shell that sets the box's hostname persistently and keeps `/etc/hosts` in
+ * step, so `sudo` and anything else resolving the local name does not stall on a
+ * hostname with no entry.
+ */
+export function buildSetHostnameScript(next: string): string {
+  const quoted = `'${next.replace(/'/g, `'"'"'`)}'`
+  return [
+    'set -eu',
+    `TS_CLOUD_OLD="$(hostname)"`,
+    `hostnamectl set-hostname ${quoted} 2>/dev/null || { echo ${quoted} > /etc/hostname && hostname ${quoted}; }`,
+    // Replace the old name where it stands rather than appending: a second
+    // 127.0.1.1 line would leave the box resolving its own name two ways.
+    `if grep -q "127.0.1.1" /etc/hosts; then`,
+    `  sed -i "s/^127\\.0\\.1\\.1.*/127.0.1.1\\t${next}/" /etc/hosts`,
+    'else',
+    `  printf '127.0.1.1\\t%s\\n' ${quoted} >> /etc/hosts`,
+    'fi',
+    'printf "%s -> %s\\n" "$TS_CLOUD_OLD" "$(hostname)"',
+  ].join('\n')
+}

--- a/packages/ts-cloud/test/drivers/compute-deploy.test.ts
+++ b/packages/ts-cloud/test/drivers/compute-deploy.test.ts
@@ -1100,3 +1100,117 @@ describe('deployAllComputeSites attach-mode service preflight', () => {
     expect(commands).not.toContain('ts_cloud_probe')
   })
 })
+
+/**
+ * Attaching resolves the owner's box by LISTING the provider with the ATTACHING
+ * project's credential, so the owner's box must be visible to it — which on a
+ * provider without per-resource scoping means write over every server in the
+ * project. Reported so it is a decision rather than a discovery.
+ */
+describe('deployAllComputeSites attach-mode credential reach', () => {
+  function attachedConfig(): CloudConfig {
+    return {
+      project: { name: 'Log HQ', slug: 'loghq', region: 'fsn1' },
+      environments: { production: { type: 'production' } },
+      cloud: { provider: 'hetzner', attachTo: 'statushq' },
+      sites: { web: { domain: 'loghq.example.com', port: 3000, root: '.output', start: 'bun run server.ts' } },
+      infrastructure: { compute: { runtime: 'bun', proxy: { engine: 'rpx' } } },
+    }
+  }
+
+  async function deployWith(reachable: Array<{ name: string, labels?: Record<string, string> }> | Error) {
+    const warnings: string[] = []
+    const infos: string[] = []
+    const driver = createMockDriver({
+      name: 'hetzner',
+      usesCloudFormation: false,
+      listReachableResources: mock(async () => {
+        if (reachable instanceof Error) throw reachable
+        return reachable
+      }),
+    })
+    const tempDir = mkdtempSync(join(tmpdir(), 'ts-cloud-reach-'))
+    const tarball = join(tempDir, 'release.tar.gz')
+    writeFileSync(tarball, 'fake tarball')
+    process.env.TS_CLOUD_UI_DISABLE = '1'
+    const ok = await deployAllComputeSites({
+      config: attachedConfig(),
+      environment: 'production',
+      driver,
+      sha: 'abc',
+      runtime: 'bun',
+      tarballForSite: () => tarball,
+      logger: {
+        info: (message: string) => infos.push(message),
+        warn: (message: string) => warnings.push(message),
+        error: () => {},
+        step: () => {},
+        success: () => {},
+      },
+    }).finally(() => {
+      delete process.env.TS_CLOUD_UI_DISABLE
+      rmSync(tempDir, { recursive: true, force: true })
+    })
+    return { ok, warnings: warnings.join('\n'), infos: infos.join('\n') }
+  }
+
+  const label = (project: string) => ({ 'ts-cloud/project': project })
+
+  it('warns, naming the servers neither project owns', async () => {
+    const { ok, warnings } = await deployWith([
+      { name: 'statushq-production-app', labels: label('statushq') },
+      { name: 'bughq-production-app', labels: label('bughq') },
+      { name: 'stacks-production-app', labels: label('stacks') },
+      { name: 'some-legacy-box' },
+    ])
+    expect(ok).toBe(true)
+    expect(warnings).toContain('all 4 server(s)')
+    expect(warnings).toContain('bughq: bughq-production-app')
+    expect(warnings).toContain('stacks: stacks-production-app')
+    expect(warnings).toContain('not managed by ts-cloud: some-legacy-box')
+  })
+
+  /**
+   * A warning that fires every time is a warning nobody reads: when the reach is
+   * exactly the two projects being joined there is nothing to decide.
+   */
+  it('stays quiet when the reach is only the two projects being joined', async () => {
+    const { ok, warnings, infos } = await deployWith([
+      { name: 'statushq-production-app', labels: label('statushq') },
+      { name: 'loghq-production-app', labels: label('loghq') },
+    ])
+    expect(ok).toBe(true)
+    expect(warnings).toBe('')
+    expect(infos).toContain('Nothing outside the two projects being joined is reachable with it.')
+  })
+
+  it('never fails the deploy when the credential cannot enumerate', async () => {
+    const { ok, warnings } = await deployWith(new Error('403 forbidden'))
+    expect(ok).toBe(true)
+    expect(warnings).toContain('403 forbidden')
+  })
+
+  it('reports nothing for a driver that cannot enumerate at all', async () => {
+    const driver = createMockDriver({ name: 'hetzner', usesCloudFormation: false })
+    expect(driver.listReachableResources).toBeUndefined()
+    const warnings: string[] = []
+    const tempDir = mkdtempSync(join(tmpdir(), 'ts-cloud-reach-'))
+    const tarball = join(tempDir, 'release.tar.gz')
+    writeFileSync(tarball, 'fake tarball')
+    process.env.TS_CLOUD_UI_DISABLE = '1'
+    const ok = await deployAllComputeSites({
+      config: attachedConfig(),
+      environment: 'production',
+      driver,
+      sha: 'abc',
+      runtime: 'bun',
+      tarballForSite: () => tarball,
+      logger: { info: () => {}, warn: (m: string) => warnings.push(m), error: () => {}, step: () => {}, success: () => {} },
+    }).finally(() => {
+      delete process.env.TS_CLOUD_UI_DISABLE
+      rmSync(tempDir, { recursive: true, force: true })
+    })
+    expect(ok).toBe(true)
+    expect(warnings.join('\n')).not.toContain('credential')
+  })
+})


### PR DESCRIPTION
Refs #169. Refs #167 (operation 3 + the scaffolding for operation 2).

## #169 — the credential radius is now stated

`describeCredentialReach()` and `formatCredentialReach()` already existed and **nothing called them** — the radius was computed, formatted, and never printed.

Attaching resolves the owner's box by LISTING the provider with the *attaching* project's own credential. That listing is the whole mechanism, and it forces shared project scope: on a provider without per-resource scoping, that is write over every server in the project. Three apps that each owned one box become three pipelines that each reach all three.

Every attach deploy now says so before acting on it:

```
Attaching to 'statushq' shares one provider project, so this deploy's credential
can write to all 4 server(s) it can see.
3 of them belong to neither project:
  bughq: bughq-production-app
  stacks: stacks-production-app
  not managed by ts-cloud: some-legacy-box
A compromised CI run or a mistargeted teardown in this project now reaches those.
```

Reported, never enforced — the trade is frequently worth making, and a deploy that started failing on upgrade would teach operators to silence the warning rather than read it. The quiet case stays quiet: reach confined to the two projects being joined is one info line.

The radius is asked of the driver (`CloudDriver.listReachableResources()`) rather than assumed from one all-powerful token, which is the "don't hardcode one credential shape" criterion: a provider whose credential *can* be scoped per-resource simply enumerates less and the same report comes out correct with no special case. Hetzner implements it over `listServers()`, where "can see" and "can delete" are the same set.

**Against the issue's checklist:** documenting the trade and the isolation/attaching exclusivity landed in #171; this adds the plan reporting and the driver-interface criterion. Narrowing the credential itself remains provider-side — Hetzner still offers nothing narrower.

## #167 — `server:rename`, on reusable plan-then-apply scaffolding

Operation 1 (attach-as-a-site) already works, as your own comment on the issue found. This adds operation 3 and the scaffolding operation 2 should be built on.

```bash
cloud server:rename bughq hq-production-server            # plan only
cloud server:rename bughq hq-production-server --apply    # perform it
```

A name is spelled in four places and the rename is only done when all four agree: the provider record, the local driver state pin, the box's hostname, and the fleet inventory record.

**The state pin is the one that is not cosmetic.** `findComputeTargets` *rejects* a pinned server whose live name no longer matches the recorded one — a deliberate guard against a stale pin sending a database operation to another project's box. So renaming at the provider alone quietly invalidates it. The provider is renamed **before** the pin is rewritten, so a crash between them leaves the pin stale (deploys fall back to label matching and keep working) rather than pinned to a name that does not exist yet.

### The scaffolding (`src/operations/plan.ts`)

Built to the control-plane requirements in the issue, and deliberately reusable:

- **Plan first.** Each step prints `from → to` before anything is touched, in declaration order, so two runs of an unchanged plan diff identically.
- **Idempotent and resumable.** Resumability comes from asking *reality* whether a step's intent already holds — not from a checkpoint file, which can disagree with the world after a crash. A half-finished operation is resumed by running it again; a finished one re-runs as `Nothing to do`.
- **Typed confirmation for the irreversible half**, and never for a step already satisfied. Rename declares nothing destructive: it is undone by renaming back, and ceremony on a reversible operation teaches people to type confirmations without reading them.
- **Non-interactive.** The plan is data and the authorization is a flag; nothing reads stdin. `--json` emits both plan and outcome.
- **Audited.** Each step reports as it starts *and* as it finishes, so a run that dies mid-step still leaves the start recorded — the case an operator is reconstructing afterwards.
- **Fails forward, not back.** A failure stops the run and leaves earlier steps applied: half-applied and reported is recoverable, silently rolled back to a state nobody verified is not.

A missing capability drops its step rather than failing the operation — a hand-enrolled server has no provider record, a label-only project has no state pin, an unpinned host key means no SSH — and the plan lists what it left out.

**Still open on #167:** operation 2, moving a deployed app between servers (data, scheduled work, TLS, DNS cutover). That is the large one and is unstarted; this PR gives it the plan/apply engine and a worked example to follow.

## Verification

`bun test` — 4097 pass, 0 fail. Typecheck and lint clean.

New coverage: `plan.test.ts` (11 cases — resume, no-op re-run, destructive gating, fail-forward, audit ordering, unknown-state handling) and `server-rename.test.ts` (14 cases — hostname validation, collision and no-op preconditions, all four records, resuming a half-finished rename, dropped capabilities, the `/etc/hosts` rewrite), plus four attach-mode credential-reach cases in `compute-deploy.test.ts`.

Docs: `docs/cli.md` gains a "Renaming a server" section with the plan output; `docs/config.md` shows the radius report and where it comes from.
