### PR TITLE
feat(fleet): move a deployed site to another server (#167 operation 2)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -155,6 +155,7 @@ See [Preview environments](/features/preview-environments) for policy, source li
 | `cloud server:ssh <name>` / `server:logs <name>` / `server:monitoring <name>` | Connect / logs / metrics. |
 | `cloud server:deploy <name>` / `server:reboot` / `server:resize <name> <type>` | Deploy / reboot / resize. |
 | `cloud server:rename <name> <new-name> [--apply]` | Rename a server in place. Prints the plan; `--apply` performs it. |
+| `cloud site:move <name> --to <server> [--apply]` | Move a deployed site to another server, DNS cutover included. |
 | `cloud server:recipe <name> <recipe>` | Run a reusable script across servers. |
 | `cloud server:worker:add/list/restart/remove` | Queue workers (Supervisor). |
 | `cloud server:cron:add/list/remove` | Scheduled jobs / cron. |
@@ -164,6 +165,53 @@ See [Preview environments](/features/preview-environments) for policy, source li
 | `cloud server:update <name>` / `server:secure <name>` | OS updates / hardening. |
 
 See [Laravel / Forge-style](/features/laravel) for the `infrastructure.compute` + `sites` config.
+
+### Moving a site to another server
+
+Consolidation's second operation: three boxes with one app each becoming one box
+with three sites.
+
+```bash
+cloud site:move bughq --to statushq-box            # plan only
+cloud site:move bughq --to statushq-box --apply    # perform it
+```
+
+It moves the site's on-box footprint wholesale — the whole
+`/var/www/<slug>-<site>` tree (every release, `shared/`, the `current` symlink)
+plus the systemd units that run it. Those units are not regenerated, they are
+moved: rebuilding from the repo on the target would not be a move but a fresh
+deploy that happens to be preceded by a data copy, picking up whatever the repo
+says today rather than what is actually running.
+
+The order is chosen so that **every prefix of the plan is a working system**,
+on the old box or the new one:
+
+| Step | Why there |
+|---|---|
+| Stop background work on the source | A queue worker writing mid-`tar` produces a torn snapshot. The web service keeps serving — the source is still live. |
+| Archive, carry, unpack, start | The target comes up but nothing routes to it yet. |
+| Health gate on the target's loopback | The public name still points at the source, so asking it would wave a broken target through. |
+| Route the site on the target | Same gateway builder the deploy uses, so a moved site is routed byte-identically to a deployed one. |
+| Cut DNS over | Only after the target has proved itself. A provider warning stops the run here rather than continuing to the drain. |
+| Drain the source | Units stopped and disabled, gateway fragment removed. **Files left in place.** |
+
+Nothing in the operation deletes anything, so a bad cutover is undone by starting
+the source's units again and pointing DNS back. That reversibility lasts until
+the source *server* is destroyed, which is a separate and deliberately separate
+command. Background units are enabled but not started on the target until the
+source is drained, so the two boxes can never both run a scheduler against one
+dataset.
+
+The archive travels through the machine running the command rather than directly
+between the boxes: a direct hop would need the target to hold a credential for
+the source, which is the same credential-radius problem consolidation already
+has. Both boxes must be enrolled with pinned host keys (`cloud server:validate`).
+
+Resuming works the same way as `server:rename` — re-run the identical command and
+the finished steps skip themselves. Two steps deliberately never skip: the
+snapshot (an archive from an earlier attempt predates whatever the source has
+served since) and the health gate (a gate that remembers a previous pass is not a
+gate).
 
 ### Renaming a server
 

--- a/packages/ts-cloud/bin/commands/site.ts
+++ b/packages/ts-cloud/bin/commands/site.ts
@@ -1,8 +1,20 @@
 import type { CLI } from '@stacksjs/clapp'
+import type { CloudConfig } from '@ts-cloud/core'
+import type { FleetServer } from '../../src/fleet'
+import type { SiteMoveEffects } from '../../src/operations/site-move'
 import { existsSync } from 'node:fs'
 import { readFile, writeFile } from 'node:fs/promises'
 import * as cli from '../../src/utils/cli'
+import { initializeDashboardControlPlane } from '../../src/deploy/dashboard-control-plane'
+import { createDnsProvider } from '../../src/dns'
+import { normalizePublicIpv6, reconcileAddressRecords, verifyAddressRecord } from '../../src/deploy/server-dns'
 import { addSiteToCloudConfig } from '../../src/deploy/site-config-editor'
+import { siteInstallBase } from '../../src/deploy/site-target'
+import { buildRpxConfig, buildRpxFragmentRefreshScript } from '../../src/drivers/shared/rpx-gateway'
+import { FleetStore, SystemFleetSshTransport } from '../../src/fleet'
+import { applyPlan, formatPlan, resolvePlan } from '../../src/operations/plan'
+import { planSiteMove, siteMoveArchivePath } from '../../src/operations/site-move'
+import { loadValidatedConfig, resolveDnsProviderConfig } from './shared'
 
 interface SiteAddOptions {
   config?: string
@@ -18,7 +30,250 @@ interface SiteAddOptions {
   dryRun?: boolean
 }
 
+interface SiteMoveCommandOptions {
+  to?: string
+  from?: string
+  apply?: boolean
+  json?: boolean
+}
+
+/**
+ * Run one script on a fleet server over the enrolled, host-key-pinned SSH
+ * endpoint, and fail loudly on a non-zero exit.
+ *
+ * Pinned-only by construction (the transport refuses anything else): a move
+ * copies an application's entire dataset between two machines, which is the last
+ * place to accept an unverified host.
+ */
+async function execOn(transport: SystemFleetSshTransport, server: FleetServer, script: string): Promise<string> {
+  const result = await transport.exec(server, script)
+  if (result.code !== 0)
+    throw new Error(`${server.name}: ${result.stderr.trim() || result.stdout.trim() || `exited ${result.code}`}`)
+  return result.stdout
+}
+
+/** `scp` one file off a server, or onto it, over the enrolled endpoint. */
+async function copyFile(server: FleetServer, from: string, to: string): Promise<void> {
+  const child = Bun.spawn(
+    ['scp', '-P', String(server.sshPort), '-o', 'BatchMode=yes', '-o', 'StrictHostKeyChecking=yes', from, to],
+    { stdout: 'pipe', stderr: 'pipe' },
+  )
+  const [code, stderr] = await Promise.all([child.exited, new Response(child.stderr).text()])
+  if (code !== 0) throw new Error(`scp failed: ${stderr.trim() || `exited ${code}`}`)
+}
+
+/**
+ * Move a deployed site to another box: plan it, print it, and perform it only
+ * when asked.
+ *
+ * The archive travels THROUGH this machine rather than directly between the two
+ * boxes. A direct hop would need the target to hold a credential for the source,
+ * which is exactly the credential-radius problem consolidation already has
+ * (#169) — and the operator running this already has verified access to both.
+ */
+async function runSiteMove(siteName: string, options: SiteMoveCommandOptions): Promise<void> {
+  if (!options.to) throw new Error('Name the target server with --to <server>.')
+
+  const config = (await loadValidatedConfig()) as CloudConfig
+  const site = config.sites?.[siteName]
+  if (!site) throw new Error(`Site '${siteName}' is not in cloud.config.ts.`)
+
+  const slug = config.project.slug
+  const controlPlane = initializeDashboardControlPlane(process.cwd(), config)
+  try {
+    const store = new FleetStore(controlPlane.store)
+    const servers = store.list(controlPlane.project.id)
+    const pick = (name: string): FleetServer => {
+      const found = servers.find((item) => item.id === name || item.name === name)
+      if (!found) throw new Error(`Server ${name} was not found. Run \`cloud server:list\`.`)
+      if (found.trustState !== 'pinned')
+        throw new Error(`${found.name} has no pinned host key. Run \`cloud server:validate ${found.name}\` first.`)
+      return found
+    }
+
+    const target = pick(options.to)
+    // Without --from, the source is the only OTHER enrolled server, which is the
+    // common shape; anything ambiguous has to be named rather than guessed.
+    const candidates = servers.filter((item) => item.id !== target.id)
+    if (!options.from && candidates.length !== 1)
+      throw new Error(
+        `Name the source server with --from <server> — ${candidates.length} others are enrolled.`,
+      )
+    const source = pick(options.from ?? candidates[0].name)
+
+    const transport = new SystemFleetSshTransport()
+    const appBase = siteInstallBase(slug, siteName)
+    const archive = siteMoveArchivePath(slug, siteName)
+    const domain = site.domain
+    const dnsName = config.infrastructure?.dns?.provider
+    const proxy = config.infrastructure?.compute?.proxy?.engine === 'rpx'
+      ? config.infrastructure.compute.proxy
+      : undefined
+    // The registrable apex: config `dns.domain` wins, else the last two labels.
+    const configuredZone = config.infrastructure?.dns?.domain as string | undefined
+    const zoneFor = (fqdn: string): string =>
+      configuredZone && fqdn.endsWith(configuredZone) ? configuredZone : fqdn.split('.').slice(-2).join('.')
+
+    const effects: SiteMoveEffects = {
+      runOnSource: (script) => execOn(transport, source, script),
+      runOnTarget: (script) => execOn(transport, target, script),
+      archiveStaged: async () => {
+        const result = await transport.exec(target, `test -f ${archive} && echo staged || true`)
+        return result.stdout.includes('staged')
+      },
+      transferArchive: async () => {
+        const local = `${process.cwd()}/.ts-cloud-move-${slug}-${siteName}.tar.gz`
+        await copyFile(source, `${source.sshUser}@${source.endpoint}:${archive}`, local)
+        await copyFile(target, local, `${target.sshUser}@${target.endpoint}:${archive}`)
+        await Bun.file(local).delete().catch(() => {})
+      },
+      targetRoutesSite: async () => {
+        if (!proxy || !domain) return true
+        const result = await transport.exec(
+          target,
+          `grep -qF ${JSON.stringify(domain)} /etc/rpx/sites.d/${slug}.json 2>/dev/null && echo routed || true`,
+        )
+        return result.stdout.includes('routed')
+      },
+      refreshTargetGateway: async () => {
+        if (!proxy)
+          throw new Error(
+            'This project does not run the rpx gateway, so the move cannot publish a route. '
+            + `Point ${target.name}'s web server at ${appBase}/current yourself, then re-run to continue.`,
+          )
+        // The SAME builder the deploy uses to write the fragment — one code
+        // path, so a moved site is routed byte-identically to a deployed one.
+        await execOn(transport, target, buildRpxFragmentRefreshScript({
+          config: buildRpxConfig(config.sites ?? {}, { proxy, slug }),
+          slug,
+          preserveManagementDashboardRoutes: true,
+        }).join('\n'))
+      },
+      publishedAddress: async () => {
+        // No hostname or no configured provider: there is no cutover to make,
+        // so report the target as already published rather than looping on a
+        // step that can never be satisfied.
+        if (!domain || !dnsName) return target.endpoint
+        const dnsConfig = resolveDnsProviderConfig(dnsName)
+        if (!dnsConfig) return undefined
+        const published = await verifyAddressRecord(
+          createDnsProvider(dnsConfig),
+          zoneFor(domain),
+          domain,
+          target.endpoint,
+          'A',
+        )
+        return published ? target.endpoint : undefined
+      },
+      cutoverDns: async () => {
+        if (!domain) return []
+        if (!dnsName) return [`No DNS provider configured — point ${domain} at ${target.endpoint} manually.`]
+        const dnsConfig = resolveDnsProviderConfig(dnsName)
+        if (!dnsConfig) return [`DNS provider '${dnsName}' is not configured.`]
+        const report = await reconcileAddressRecords({
+          provider: createDnsProvider(dnsConfig),
+          zone: zoneFor(domain),
+          fqdn: domain,
+          ipv4: target.endpoint,
+          ipv6: normalizePublicIpv6(undefined),
+        })
+        return report.warnings
+      },
+    }
+
+    const plan = await planSiteMove(
+      {
+        slug,
+        siteName,
+        appBase,
+        from: source.name,
+        to: target.name,
+        targetAddress: target.endpoint,
+        port: site.port,
+        healthCheckPath: site.healthCheck?.path,
+      },
+      effects,
+    )
+    const resolved = await resolvePlan(plan)
+
+    if (!options.apply) {
+      if (options.json) {
+        console.log(
+          JSON.stringify(
+            {
+              schemaVersion: 1,
+              operation: plan.operation,
+              target: plan.target,
+              move: { site: siteName, from: source.name, to: target.name, address: target.endpoint },
+              steps: resolved.map((item) => ({
+                id: item.step.id,
+                title: item.step.title,
+                state: item.state,
+                change: item.step.change,
+                reason: item.reason,
+              })),
+            },
+            null,
+            2,
+          ),
+        )
+        return
+      }
+      for (const line of formatPlan(plan, resolved)) console.log(line)
+      console.log(`  The source keeps its files either way — reversible until ${source.name} is destroyed.`)
+      console.log('  Re-run with --apply to perform it.')
+      return
+    }
+
+    const outcome = await applyPlan(plan, resolved, {
+      log: (message) => cli.info(message),
+      audit: (event) =>
+        controlPlane.store.appendEvent({
+          projectId: controlPlane.project.id,
+          type: `${event.operation}.${event.step}.${event.state}`,
+          level: event.state === 'failed' ? 'error' : 'info',
+          payload: {
+            site: siteName,
+            from: source.name,
+            to: target.name,
+            ...(event.error ? { error: event.error } : {}),
+          },
+        }),
+    })
+
+    if (options.json) console.log(JSON.stringify({ schemaVersion: 1, outcome }, null, 2))
+    if (!outcome.success) {
+      const failed = outcome.steps.find((step) => step.state === 'failed')
+      throw new Error(
+        `${plan.operation} stopped at '${failed?.title}': ${failed?.error}. `
+        + `${source.name} still has the site and its files; re-run the same command to continue from here.`,
+      )
+    }
+    if (!options.json)
+      cli.success(
+        `Moved ${siteName} from ${source.name} to ${target.name}. `
+        + `${source.name} keeps its copy until you destroy it.`,
+      )
+  } finally {
+    controlPlane.store.close()
+  }
+}
+
 export function registerSiteCommands(app: CLI): void {
+  app
+    .command('site:move <name>', 'Move a deployed site to another server')
+    .option('--to <server>', 'Target server (enrolled name or id)')
+    .option('--from <server>', 'Source server; inferred when only one other is enrolled')
+    .option('--apply', 'Perform the reviewed move plan')
+    .option('--json', 'Print structured JSON')
+    .action(async (name: string, options: SiteMoveCommandOptions) => {
+      try {
+        await runSiteMove(name, options)
+      } catch (error) {
+        cli.error(error instanceof Error ? error.message : String(error))
+        process.exitCode = 1
+      }
+    })
   app
     .command('site:add <name>', 'Add a site entry to cloud.config.ts')
     .option('--config <path>', 'Path to cloud config file')

--- a/packages/ts-cloud/src/operations/site-move.test.ts
+++ b/packages/ts-cloud/src/operations/site-move.test.ts
@@ -1,0 +1,287 @@
+import type { SiteMoveEffects } from './site-move'
+import { describe, expect, it } from 'bun:test'
+import { applyPlan, formatPlan, resolvePlan } from './plan'
+import {
+  buildDrainSourceScript,
+  buildHealthGateScript,
+  buildPauseWorkersScript,
+  buildRestoreScript,
+  buildSnapshotScript,
+  buildSourceStateScript,
+  buildWorkersStateScript,
+  parseSourceDrained,
+  parseTargetReady,
+  parseWorkersPaused,
+  planSiteMove,
+  siteMoveArchivePath,
+
+} from './site-move'
+
+const options = {
+  slug: 'hq',
+  siteName: 'bughq',
+  appBase: '/var/www/hq-bughq',
+  from: 'bughq-box',
+  to: 'statushq-box',
+  targetAddress: '203.0.113.9',
+  port: 3010,
+}
+
+/** A world where the move has not started: source serving, target empty. */
+function world() {
+  const state = {
+    workersRunning: true,
+    onTarget: false,
+    targetRunning: false,
+    staged: false,
+    published: '203.0.113.1',
+    routed: false,
+    sourceRunning: true,
+    ran: [] as string[],
+  }
+  const effects: SiteMoveEffects = {
+    runOnSource: async (script) => {
+      state.ran.push(`source:${script.slice(0, 24)}`)
+      if (script === buildWorkersStateScript('hq', 'bughq'))
+        return state.workersRunning ? 'active:hq-bughq-scheduler.service' : ''
+      if (script === buildSourceStateScript('hq', 'bughq'))
+        return state.sourceRunning ? 'active:hq-bughq.service' : ''
+      if (script.startsWith('set -eu\nfor unit') && script.includes('systemctl stop')) state.workersRunning = false
+      if (script.includes('disable --now')) { state.sourceRunning = false; state.workersRunning = false }
+      if (script.includes('tar czf')) state.staged = false
+      return ''
+    },
+    runOnTarget: async (script) => {
+      state.ran.push(`target:${script.slice(0, 24)}`)
+      if (script.startsWith('test -d'))
+        return `${state.onTarget ? 'tree:present' : 'tree:absent'}\n${state.targetRunning ? 'unit:active' : 'unit:inactive'}`
+      if (script.includes('tar xzf')) { state.onTarget = true; state.targetRunning = true }
+      if (script.includes('curl')) {
+        if (!state.targetRunning) throw new Error('no healthy response')
+        return 'healthy'
+      }
+      return ''
+    },
+    transferArchive: async () => { state.staged = true },
+    archiveStaged: async () => state.staged,
+    cutoverDns: async () => { state.published = options.targetAddress; return [] },
+    publishedAddress: async () => state.published,
+    refreshTargetGateway: async () => { state.routed = true },
+    targetRoutesSite: async () => state.routed,
+  }
+  return { state, effects }
+}
+
+describe('planSiteMove ordering', () => {
+  /**
+   * Every prefix of the plan has to be a working system — on the old box or the
+   * new one. The source keeps serving until the target passes a health gate,
+   * DNS moves only after that, and the source is drained last.
+   */
+  it('gates health before routing, routes before DNS, and drains last', async () => {
+    const p = await planSiteMove(options, world().effects)
+    expect(p.steps.map(step => step.id)).toEqual([
+      'pause-workers',
+      'snapshot',
+      'transfer',
+      'restore',
+      'health',
+      'gateway',
+      'dns',
+      'drain-source',
+    ])
+  })
+
+  /** A worker or scheduler binds no port; gating on one would fail every move. */
+  it('omits the health gate for a portless site', async () => {
+    const p = await planSiteMove({ ...options, port: undefined }, world().effects)
+    expect(p.steps.map(step => step.id)).not.toContain('health')
+  })
+
+  it('refuses a move to the box the site is already on', async () => {
+    await expect(planSiteMove({ ...options, to: options.from }, world().effects)).rejects.toThrow('already on')
+  })
+
+  /**
+   * Nothing here deletes: the source tree survives, so a bad cutover is undone
+   * by starting the units again. Irreversibility begins at `server:destroy`.
+   */
+  it('declares no destructive step, because the source is drained and not deleted', async () => {
+    const p = await planSiteMove(options, world().effects)
+    expect(p.steps.some(step => step.destructive)).toBe(false)
+  })
+})
+
+describe('planSiteMove execution', () => {
+  it('moves the site end to end', async () => {
+    const { state, effects } = world()
+    const p = await planSiteMove(options, effects)
+    const outcome = await applyPlan(p, await resolvePlan(p))
+    expect(outcome.success).toBe(true)
+    expect(state.onTarget).toBe(true)
+    expect(state.targetRunning).toBe(true)
+    expect(state.routed).toBe(true)
+    expect(state.published).toBe('203.0.113.9')
+    expect(state.sourceRunning).toBe(false)
+  })
+
+  /**
+   * A cutover that reports success while editing nothing is the failure the
+   * whole ordering exists to avoid — it must not reach the drain.
+   */
+  it('refuses to drain the source when DNS reported a warning', async () => {
+    const { state, effects } = world()
+    const p = await planSiteMove(options, {
+      ...effects,
+      cutoverDns: async () => ['bughq.example.com → 203.0.113.9 failed: zone not found'],
+    })
+    const outcome = await applyPlan(p, await resolvePlan(p))
+    expect(outcome.success).toBe(false)
+    expect(outcome.steps.at(-1)?.id).toBe('dns')
+    expect(state.sourceRunning).toBe(true)
+  })
+
+  it('leaves the source serving when the target never becomes healthy', async () => {
+    const { state, effects } = world()
+    const p = await planSiteMove(options, {
+      ...effects,
+      runOnTarget: async (script) => {
+        if (script.startsWith('test -d')) return 'tree:absent\nunit:inactive'
+        if (script.includes('curl')) throw new Error('no healthy response from http://127.0.0.1:3010/')
+        return ''
+      },
+    })
+    const outcome = await applyPlan(p, await resolvePlan(p))
+    expect(outcome.success).toBe(false)
+    expect(outcome.steps.at(-1)?.id).toBe('health')
+    expect(state.published).toBe('203.0.113.1')
+    expect(state.sourceRunning).toBe(true)
+  })
+
+  /** The point of the scaffolding: a run that died is resumed, not restarted. */
+  it('resumes after a failed cutover without re-transferring', async () => {
+    const { state, effects } = world()
+    let transfers = 0
+    const counted = { ...effects, transferArchive: async () => { transfers++; await effects.transferArchive() } }
+    let failDns = true
+    const withFlakyDns = {
+      ...counted,
+      cutoverDns: async () => (failDns ? ['provider timed out'] : counted.cutoverDns()),
+    }
+
+    const first = await planSiteMove(options, withFlakyDns)
+    expect((await applyPlan(first, await resolvePlan(first))).success).toBe(false)
+    expect(transfers).toBe(1)
+
+    failDns = false
+    const second = await planSiteMove(options, withFlakyDns)
+    const resolved = await resolvePlan(second)
+    // Everything up to the cutover is already done and skips itself.
+    expect(resolved.find(item => item.step.id === 'transfer')?.state).toBe('satisfied')
+    expect(resolved.find(item => item.step.id === 'restore')?.state).toBe('satisfied')
+    expect((await applyPlan(second, resolved)).success).toBe(true)
+    expect(transfers).toBe(1)
+    expect(state.sourceRunning).toBe(false)
+  })
+
+  /**
+   * The health gate decides whether traffic may move. A gate that remembers a
+   * previous pass is not a gate.
+   */
+  it('re-runs the health gate on every attempt', async () => {
+    const p = await planSiteMove(options, world().effects)
+    const resolved = await resolvePlan(p)
+    expect(resolved.find(item => item.step.id === 'health')?.state).toBe('pending')
+    expect(resolved.find(item => item.step.id === 'snapshot')?.state).toBe('pending')
+  })
+
+  it('prints a plan that names both boxes before touching anything', async () => {
+    const { state, effects } = world()
+    const p = await planSiteMove(options, effects)
+    const lines = formatPlan(p, await resolvePlan(p)).join('\n')
+    expect(lines).toContain('site:move bughq')
+    expect(lines).toContain('bughq-box:/var/www/hq-bughq → /tmp/ts-cloud-move-hq-bughq.tar.gz')
+    expect(lines).toContain('bughq-box → 203.0.113.9')
+    // A plan changes nothing.
+    expect(state.onTarget).toBe(false)
+    expect(state.sourceRunning).toBe(true)
+    expect(state.workersRunning).toBe(true)
+  })
+})
+
+describe('remote scripts', () => {
+  /**
+   * Dereferencing symlinks would flatten `current` into a second copy of the
+   * live release and turn every shared path back into a per-release file — the
+   * exact failure `sharedPaths` exists to prevent.
+   */
+  it('archives the tree without dereferencing symlinks', () => {
+    const script = buildSnapshotScript('hq', 'bughq', '/var/www/hq-bughq')
+    expect(script).toContain('tar czf')
+    expect(script).not.toContain('tar czhf')
+    expect(script).not.toContain(' -h ')
+    expect(script).toContain('hq-bughq*.service')
+  })
+
+  it('carries the unit files alongside the tree', () => {
+    expect(buildRestoreScript('hq', 'bughq', '/var/www/hq-bughq')).toContain('-C /etc/systemd/system')
+    expect(buildSnapshotScript('hq', 'bughq', '/var/www/hq-bughq')).toContain('-C /etc/systemd/system')
+  })
+
+  /** Two boxes running one scheduler against one dataset is the thing to avoid. */
+  it('starts the app on the target but not its background units', () => {
+    const script = buildRestoreScript('hq', 'bughq', '/var/www/hq-bughq')
+    expect(script).toContain('systemctl restart hq-bughq.service')
+    expect(script).not.toContain('scheduler')
+    expect(script).not.toContain('queue')
+  })
+
+  /** The public name still points at the SOURCE at gate time. */
+  it('polls loopback, never the public name', () => {
+    const script = buildHealthGateScript(3010, '/health')
+    expect(script).toContain('http://127.0.0.1:3010/health')
+    expect(script).not.toContain('bughq')
+  })
+
+  it('normalizes a health path without a leading slash', () => {
+    expect(buildHealthGateScript(3010, 'health')).toContain('http://127.0.0.1:3010/health')
+  })
+
+  it('pauses only background units, leaving the site serving', () => {
+    const script = buildPauseWorkersScript('hq', 'bughq')
+    expect(script).toContain('queue|daemon')
+    expect(script).toContain('scheduler')
+    expect(script).toContain('systemctl stop')
+    expect(script).not.toContain('disable')
+  })
+
+  it('drains every unit on the source but deletes no files', () => {
+    const script = buildDrainSourceScript('hq', 'bughq')
+    expect(script).toContain('systemctl disable --now')
+    expect(script).toContain('rm -f /etc/rpx/sites.d/hq.json')
+    expect(script).not.toContain('/var/www')
+    expect(script).not.toContain('rm -rf')
+  })
+
+  /** A dry run must not change the world — the checks only report. */
+  it('checks state without mutating it', () => {
+    for (const script of [buildWorkersStateScript('hq', 'bughq'), buildSourceStateScript('hq', 'bughq')]) {
+      expect(script).not.toContain('systemctl stop')
+      expect(script).not.toContain('systemctl disable')
+      expect(script).not.toContain('rm ')
+    }
+  })
+
+  it('parses unit and tree state', () => {
+    expect(parseWorkersPaused('')).toBe(true)
+    expect(parseWorkersPaused('active:hq-bughq-scheduler.service')).toBe(false)
+    expect(parseSourceDrained('active:hq-bughq.service')).toBe(false)
+    expect(parseTargetReady('tree:present\nunit:active')).toBe(true)
+    expect(parseTargetReady('tree:present\nunit:inactive')).toBe(false)
+    expect(parseTargetReady('tree:absent\nunit:active')).toBe(false)
+  })
+
+  it('stages the archive under a slug- and site-scoped name', () => {
+    expect(siteMoveArchivePath('hq', 'bughq')).toBe('/tmp/ts-cloud-move-hq-bughq.tar.gz')
+  })
+})

--- a/packages/ts-cloud/src/operations/site-move.ts
+++ b/packages/ts-cloud/src/operations/site-move.ts
@@ -1,0 +1,361 @@
+/**
+ * Move a deployed site from one box to another.
+ *
+ * The second of the consolidation operations: three boxes with one app each
+ * should be able to become one box with three sites, and today that is an
+ * afternoon of SSH. What makes it an afternoon is not the individual steps but
+ * the fact that a half-finished one leaves nothing to tell you what already
+ * happened — so this is expressed as a plan on the same scaffolding as
+ * `server:rename` (see `./plan`), where every step re-derives its own state and
+ * a run that dies is resumed by running it again.
+ *
+ * It moves the site's on-box footprint WHOLESALE — the whole
+ * `/var/www/<slug>-<site>` tree (every release, `shared/`, and the `current`
+ * symlink) plus the systemd units that run it. Copying those units is not a
+ * parallel mechanism: they are literally the units the deploy wrote, moved. The
+ * alternative, rebuilding from the repo on the target, would not be a move — it
+ * would be a fresh deploy that happens to be preceded by a data copy, and it
+ * would silently pick up whatever the repo says today rather than what is
+ * actually running.
+ *
+ * **Nothing here is irreversible.** The source's tree is never deleted, only
+ * drained: its units are stopped and disabled and its gateway route removed, so
+ * a bad cutover is undone by starting them again and pointing DNS back. That is
+ * the reversibility the operation is required to have — it lasts until the
+ * source SERVER is deleted, which is a separate, deliberately separate,
+ * destructive operation (`server:destroy`).
+ *
+ * Ordering is chosen for what a failure in the middle leaves behind. The source
+ * keeps serving until the target has passed a health gate, DNS is cut over only
+ * after that, and the source is drained last — so every prefix of this plan is a
+ * working system, either on the old box or the new one.
+ *
+ * @see https://github.com/stacksjs/ts-cloud/issues/167
+ */
+import type { OperationPlan, OperationStep } from './plan'
+
+/** Where a snapshot archive is staged on both boxes. */
+export function siteMoveArchivePath(slug: string, siteName: string): string {
+  return `/tmp/ts-cloud-move-${slug}-${siteName}.tar.gz`
+}
+
+/** Systemd unit-file glob covering a site's app, scheduler, queue and daemon units. */
+export function siteUnitGlob(slug: string, siteName: string): string {
+  return `${slug}-${siteName}*.service`
+}
+
+/** Single-quote a value for safe embedding in the generated shell. */
+function sh(value: string): string {
+  return `'${value.split('\'').join('\'\\\'\'')}'`
+}
+
+/**
+ * Stop the site's BACKGROUND units on the source — scheduler, queue workers,
+ * daemons — leaving the web service running.
+ *
+ * The snapshot has to be consistent, and background work is what writes to it: a
+ * queue worker committing to a SQLite database halfway through `tar` produces an
+ * archive with a torn page in it. The web service keeps serving because the
+ * source is still the live site at this point; read traffic during the copy is
+ * fine, and stopping it here would be an outage taken long before the target is
+ * ready to replace it.
+ */
+export function buildPauseWorkersScript(slug: string, siteName: string): string {
+  return [
+    'set -eu',
+    `for unit in $(ls /etc/systemd/system/ 2>/dev/null | grep -E ${sh(backgroundUnitPattern(slug, siteName))} || true); do`,
+    '  systemctl stop "$unit" 2>/dev/null || true',
+    'done',
+  ].join('\n')
+}
+
+/** Background units for a site: scheduler, queue workers, daemons. */
+function backgroundUnitPattern(slug: string, siteName: string): string {
+  return `^${slug}-${siteName}-((queue|daemon)-.*|scheduler)\\.service$`
+}
+
+/**
+ * Read-only companion to {@link buildPauseWorkersScript}. Separate because a
+ * plan's `satisfied()` must never mutate: if checking whether the workers are
+ * paused also paused them, a dry run would change the world.
+ */
+export function buildWorkersStateScript(slug: string, siteName: string): string {
+  return reportActiveUnits(backgroundUnitPattern(slug, siteName))
+}
+
+/** Emit one `active:<unit>` line per running unit matching `pattern`. */
+function reportActiveUnits(pattern: string): string {
+  return [
+    `ls /etc/systemd/system/ 2>/dev/null | grep -E ${sh(pattern)} | while read -r unit; do`,
+    '  systemctl is-active "$unit" >/dev/null 2>&1 && echo "active:$unit" || true',
+    'done',
+  ].join('\n')
+}
+
+/** Are the site's background units all stopped on the source? */
+export function parseWorkersPaused(output: string): boolean {
+  return !output.split('\n').some(line => line.trim().startsWith('active:'))
+}
+
+/**
+ * Archive the site's whole footprint on the source: its install tree and its
+ * unit files, in one tarball.
+ *
+ * `-h` is deliberately NOT passed: `current` and the shared-path symlinks must
+ * stay symlinks. Dereferencing them would flatten `current` into a second copy
+ * of the live release and turn every shared path into a per-release file again —
+ * which is the exact failure `sharedPaths` exists to prevent.
+ */
+export function buildSnapshotScript(slug: string, siteName: string, appBase: string): string {
+  const archive = siteMoveArchivePath(slug, siteName)
+  return [
+    'set -eu',
+    `test -d ${sh(appBase)} || { echo "no site tree at ${appBase}" >&2; exit 1; }`,
+    `rm -f ${sh(archive)}`,
+    // Two roots in one archive, each stored relative to its own parent so the
+    // restore can place them without a path-rewriting step.
+    `tar czf ${sh(archive)}`
+    + ` -C "$(dirname ${sh(appBase)})" "$(basename ${sh(appBase)})"`
+    + ` -C /etc/systemd/system $(cd /etc/systemd/system && ls ${siteUnitGlob(slug, siteName)} 2>/dev/null | tr '\\n' ' ')`,
+    `sha256sum ${sh(archive)} | cut -d' ' -f1`,
+  ].join('\n')
+}
+
+/**
+ * Unpack the archive on the target and bring the app up.
+ *
+ * The app unit is started but the gateway is not yet pointed at it: the site
+ * has to answer on loopback before anything is routed to it, and DNS is not
+ * touched until it has. Background units are enabled but NOT started — they stay
+ * paused until the source has been drained, so the two boxes can never both be
+ * running the same scheduler against the same data.
+ */
+export function buildRestoreScript(slug: string, siteName: string, appBase: string): string {
+  const archive = siteMoveArchivePath(slug, siteName)
+  return [
+    'set -eu',
+    `test -f ${sh(archive)} || { echo "archive not staged at ${archive}" >&2; exit 1; }`,
+    `mkdir -p "$(dirname ${sh(appBase)})"`,
+    // Extract the tree first, then the units, from the same archive.
+    `tar xzf ${sh(archive)} -C "$(dirname ${sh(appBase)})" "$(basename ${sh(appBase)})"`,
+    `tar xzf ${sh(archive)} -C /etc/systemd/system --wildcards ${sh(siteUnitGlob(slug, siteName))} 2>/dev/null || true`,
+    'systemctl daemon-reload',
+    `systemctl enable ${slug}-${siteName}.service 2>/dev/null || true`,
+    `systemctl restart ${slug}-${siteName}.service`,
+    `rm -f ${sh(archive)}`,
+  ].join('\n')
+}
+
+/** Is the site's tree already on the target, with its app unit running? */
+export function buildTargetStateScript(slug: string, siteName: string, appBase: string): string {
+  return [
+    `test -d ${sh(appBase)} && echo tree:present || echo tree:absent`,
+    `systemctl is-active ${slug}-${siteName}.service >/dev/null 2>&1 && echo unit:active || echo unit:inactive`,
+  ].join('\n')
+}
+
+/** Does the target already hold the site's tree AND run its app unit? */
+export function parseTargetReady(output: string): boolean {
+  return output.includes('tree:present') && output.includes('unit:active')
+}
+
+/**
+ * Health gate on the target, before any traffic is sent to it.
+ *
+ * Polls loopback rather than the public name on purpose: the public name still
+ * points at the SOURCE at this point in the plan, so asking it would cheerfully
+ * report the old box as healthy and wave a broken target through.
+ */
+export function buildHealthGateScript(port: number, path = '/', attempts = 10): string {
+  const url = `http://127.0.0.1:${port}${path.startsWith('/') ? path : `/${path}`}`
+  return [
+    'set -eu',
+    `for i in $(seq 1 ${attempts}); do`,
+    `  if curl -fsS -o /dev/null --max-time 5 ${sh(url)}; then echo healthy; exit 0; fi`,
+    '  sleep 3',
+    'done',
+    `echo "no healthy response from ${url}" >&2`,
+    'exit 1',
+  ].join('\n')
+}
+
+/**
+ * Drain the site on the source: stop and disable every unit, and drop its
+ * gateway fragment so the old box stops answering for it.
+ *
+ * The tree is left exactly where it is. That is what keeps the whole operation
+ * reversible: undoing a bad cutover is `systemctl start` plus pointing DNS back,
+ * with the data still sitting on the source. It stops being reversible when the
+ * source SERVER is deleted, which this operation deliberately does not do.
+ */
+export function buildDrainSourceScript(slug: string, siteName: string): string {
+  return [
+    'set -eu',
+    `for unit in $(ls /etc/systemd/system/ 2>/dev/null | grep -E ${sh(siteUnitPattern(slug, siteName))} || true); do`,
+    '  systemctl disable --now "$unit" 2>/dev/null || true',
+    'done',
+    `rm -f /etc/rpx/sites.d/${slug}.json 2>/dev/null || true`,
+    'systemctl reload rpx-gateway.service 2>/dev/null || systemctl restart rpx-gateway.service 2>/dev/null || true',
+  ].join('\n')
+}
+
+/** Every unit belonging to a site: the app, its template, and its background units. */
+function siteUnitPattern(slug: string, siteName: string): string {
+  return `^${slug}-${siteName}[-@.]`
+}
+
+/**
+ * Read-only companion to {@link buildDrainSourceScript} — see
+ * {@link buildWorkersStateScript} for why the two are not one script.
+ */
+export function buildSourceStateScript(slug: string, siteName: string): string {
+  return reportActiveUnits(siteUnitPattern(slug, siteName))
+}
+
+/** Is the site fully stopped on the source? */
+export function parseSourceDrained(output: string): boolean {
+  return !output.split('\n').some(line => line.trim().startsWith('active:'))
+}
+
+/**
+ * The side effects a move needs, injected so the operation is testable without
+ * two live boxes, a provider, or a DNS account.
+ */
+export interface SiteMoveEffects {
+  /** Run a script on the source box; resolves with stdout, rejects on failure. */
+  runOnSource: (script: string) => Promise<string>
+  /** Run a script on the target box. */
+  runOnTarget: (script: string) => Promise<string>
+  /**
+   * Carry the staged archive from the source to the target. Separate from the
+   * two exec effects because how bytes get between two boxes is a deployment
+   * decision — through the operator, over a direct SSH hop, via object storage —
+   * and none of it belongs in this plan.
+   */
+  transferArchive: () => Promise<void>
+  /** Is the archive already staged on the target? Lets the transfer resume. */
+  archiveStaged: () => Promise<boolean>
+  /** Point the site's hostname at the target. Resolves with any provider warnings. */
+  cutoverDns: () => Promise<string[]>
+  /** Address the site's hostname currently publishes, for the cutover check. */
+  publishedAddress: () => Promise<string | undefined>
+  /** Refresh the target's gateway so it routes the site. */
+  refreshTargetGateway: () => Promise<void>
+  /** Does the target's gateway already route this site? */
+  targetRoutesSite: () => Promise<boolean>
+}
+
+export interface SiteMoveOptions {
+  slug: string
+  siteName: string
+  /** Install base on both boxes — `siteInstallBase(slug, siteName)`. */
+  appBase: string
+  /** Source and target box names, for the plan's own prose. */
+  from: string
+  to: string
+  /** Target's public address, which DNS is cut over to. */
+  targetAddress: string
+  /** Loopback port the health gate polls. Omitted for a portless site. */
+  port?: number
+  /** Health-check path, defaulting to `/`. */
+  healthCheckPath?: string
+}
+
+/**
+ * Build the plan that moves `siteName` from one box to another.
+ *
+ * Async because the preconditions — the site exists on the source, the target is
+ * not already serving a different tree there — are checked here rather than
+ * becoming steps. A precondition is not a unit of work.
+ */
+export async function planSiteMove(options: SiteMoveOptions, effects: SiteMoveEffects): Promise<OperationPlan> {
+  const { slug, siteName, appBase, from, to, targetAddress } = options
+
+  if (from === to) throw new Error(`'${siteName}' is already on ${to}.`)
+
+  const steps: OperationStep[] = [
+    {
+      id: 'pause-workers',
+      title: `Stop background work on ${from} so the snapshot is consistent`,
+      satisfied: async () => parseWorkersPaused(await effects.runOnSource(buildWorkersStateScript(slug, siteName))),
+      apply: async () => {
+        await effects.runOnSource(buildPauseWorkersScript(slug, siteName))
+      },
+    },
+    {
+      id: 'snapshot',
+      title: `Archive the site's tree and units on ${from}`,
+      change: { from: `${from}:${appBase}`, to: siteMoveArchivePath(slug, siteName) },
+      // Always re-taken: an archive from an earlier attempt predates whatever
+      // the source served since, and a move that silently shipped stale data
+      // would be worse than one that copies twice.
+      satisfied: async () => false,
+      apply: async () => {
+        await effects.runOnSource(buildSnapshotScript(slug, siteName, appBase))
+      },
+    },
+    {
+      id: 'transfer',
+      title: `Carry the archive to ${to}`,
+      change: { from, to },
+      satisfied: () => effects.archiveStaged(),
+      apply: () => effects.transferArchive(),
+    },
+    {
+      id: 'restore',
+      title: `Unpack the site on ${to} and start it`,
+      change: { from: siteMoveArchivePath(slug, siteName), to: `${to}:${appBase}` },
+      satisfied: async () => parseTargetReady(await effects.runOnTarget(buildTargetStateScript(slug, siteName, appBase))),
+      apply: async () => {
+        await effects.runOnTarget(buildRestoreScript(slug, siteName, appBase))
+      },
+    },
+  ]
+
+  // A portless site — a worker or a scheduler — has nothing to poll, and gating
+  // on a port it never binds would fail every move of one.
+  if (options.port != null) {
+    const { port } = options
+    steps.push({
+      id: 'health',
+      title: `Wait for the site to answer on ${to} (127.0.0.1:${port})`,
+      // Re-run every time: this is the gate that decides whether traffic may be
+      // moved, and a gate that remembers a previous pass is not a gate.
+      satisfied: async () => false,
+      apply: async () => {
+        await effects.runOnTarget(buildHealthGateScript(port, options.healthCheckPath ?? '/'))
+      },
+    })
+  }
+
+  steps.push(
+    {
+      id: 'gateway',
+      title: `Route the site on ${to}`,
+      satisfied: () => effects.targetRoutesSite(),
+      apply: () => effects.refreshTargetGateway(),
+    },
+    {
+      id: 'dns',
+      title: `Point DNS at ${to}`,
+      change: { from: `${from}`, to: targetAddress },
+      satisfied: async () => (await effects.publishedAddress()) === targetAddress,
+      apply: async () => {
+        const warnings = await effects.cutoverDns()
+        // A cutover that reported success while editing nothing is the failure
+        // this whole ordering exists to avoid; refuse to continue to the drain.
+        if (warnings.length > 0) throw new Error(warnings.join('; '))
+      },
+    },
+    {
+      id: 'drain-source',
+      title: `Stop the site on ${from}, leaving its files in place`,
+      satisfied: async () => parseSourceDrained(await effects.runOnSource(buildSourceStateScript(slug, siteName))),
+      apply: async () => {
+        await effects.runOnSource(buildDrainSourceScript(slug, siteName))
+      },
+    },
+  )
+
+  return { operation: 'site:move', target: siteName, steps }
+}


### PR DESCRIPTION
Closes #167.

This is the last of the three consolidation operations. For the record on where the other two stand: **operation 1** (attach an app as a site) already worked — your own comment on the issue found it, and #174 added its two guardrails; **operation 3** (`server:rename`) shipped in #175 along with the plan/apply scaffolding this builds on. This adds **operation 2**, moving a deployed app between servers.

```bash
cloud site:move bughq --to statushq-box            # plan only
cloud site:move bughq --to statushq-box --apply    # perform it
```

## What it moves

The site's on-box footprint **wholesale** — the whole `/var/www/<slug>-<site>` tree (every release, `shared/`, the `current` symlink) plus the systemd units that run it.

The units are *moved*, not regenerated. Rebuilding from the repo on the target would not be a move: it would be a fresh deploy that happens to be preceded by a data copy, picking up whatever the repo says today rather than what is actually running. `tar` keeps symlinks for the same reason — dereferencing would flatten `current` into a second copy of the live release and turn every shared path back into a per-release file, which is exactly the failure `sharedPaths` exists to prevent (and exactly what #172 was about).

## The ordering is the design

Every prefix of the plan is a working system, on the old box or the new one:

| Step | Why it is there |
|---|---|
| Stop background work on the source | A queue worker committing mid-`tar` produces a torn snapshot. The web service keeps serving — the source is still live, and stopping it here would be an outage taken long before the target can replace it. |
| Archive → carry → unpack → start | The target comes up, but nothing routes to it yet. |
| Health gate on the target's **loopback** | The public name still points at the source, so asking it would cheerfully report the old box as healthy and wave a broken target through. |
| Route the site on the target | Uses `buildRpxFragmentRefreshScript` — the same builder the deploy uses, so a moved site is routed byte-identically to a deployed one rather than by a second mechanism that drifts. |
| Cut DNS over | Only after the target has proved itself. A provider warning stops the run **here**, rather than continuing to drain the source on the strength of a cutover that may have edited nothing. |
| Drain the source | Units stopped and disabled, gateway fragment removed. **Files left in place.** |

## Reversibility

Nothing in the operation deletes anything. A bad cutover is undone by starting the source's units again and pointing DNS back, with the data still sitting on the source — which is the reversibility the issue asks for, lasting until the source *server* is destroyed. That stays a separate, deliberately separate, destructive command, so `site:move` declares no destructive step and needs no typed confirmation.

Background units are enabled but **not started** on the target until the source is drained, so the two boxes can never both run a scheduler against one dataset.

## Resume

Re-run the identical command and finished steps skip themselves. Two deliberately never skip:

- **the snapshot** — an archive from an earlier attempt predates whatever the source has served since, and silently shipping stale data is worse than copying twice;
- **the health gate** — a gate that remembers a previous pass is not a gate.

The `satisfied()` checks are strictly read-only (there are separate state-reporting scripts from the acting ones), so a plan run changes nothing on either box.

## Transfer path

The archive travels through the machine running the command rather than directly between the two boxes. A direct hop would need the target to hold a credential for the source — the same credential-radius problem consolidation already has (#169). Both boxes must be enrolled with pinned host keys; the transport refuses anything else, which is the right bar for copying an application's entire dataset between machines.

## Against the issue's checklist

- [x] An app can be attached to a server that already hosts another (#174 guardrails on the existing path)
- [x] An app can be moved from server A to server B, including data and scheduled work, without a manual SSH step
- [x] DNS cutover is part of the operation and reversible until the source server is deleted
- [x] A server can be renamed without being recreated (#175)
- [x] The full sequence runs unattended from CI and is safe to re-run after a failure — plan is data, authorization is a flag, nothing reads stdin, `--json` for both plan and outcome
- [x] `--dry-run` shows the complete plan — it is the default; `--apply` is what performs it

## Verification

`bun test` — 4125 pass, 0 fail. Typecheck and lint clean.

20 new cases in `site-move.test.ts`: step ordering, the portless-site case, end-to-end execution, the source left serving when the target never goes healthy, the drain refused after a DNS warning, resuming a failed cutover without re-transferring, the health gate re-running every attempt, a plan changing nothing, and the remote scripts (symlinks preserved, units carried, background units not started, loopback-only gate, read-only checks, no `rm -rf` anywhere near `/var/www`).
