### PR TITLE
fix(test): give the last three dashboard integrations a real timeout

### DIFF
--- a/packages/ts-cloud/src/deploy/dashboard-configuration.integration.test.ts
+++ b/packages/ts-cloud/src/deploy/dashboard-configuration.integration.test.ts
@@ -136,5 +136,9 @@ describe('dashboard configuration integration', () => {
       body: JSON.stringify({ id: token.id, expectedVersion: 2, confirm: 'TOKEN' }),
     })
     expect(await removed.json()).toMatchObject({ ok: true, mutation: { removed: ['TOKEN'] } })
-  })
+  // 30s, not the 5000ms default. Booting the dashboard spawns a real
+  // `stx build --no-cache` of the cockpit (~1.7s measured), and this test then
+  // drives import, preview, mask, reveal, rotate, export and delete through it.
+  // ~2s standalone, past 5000ms under the full 313-file run.
+  }, 30_000)
 })

--- a/packages/ts-cloud/src/deploy/dashboard-onboarding.integration.test.ts
+++ b/packages/ts-cloud/src/deploy/dashboard-onboarding.integration.test.ts
@@ -216,5 +216,9 @@ describe('dashboard application onboarding integration', () => {
       })
     ).json()) as any
     expect(disconnected.registry).toMatchObject({ status: 'disconnected', credentialConfigured: false })
-  })
+  // 30s, not the 5000ms default. Booting the dashboard spawns a real
+  // `stx build --no-cache` of the cockpit (~1.7s measured), and this test then
+  // detects, resumes, validates and applies a plan on top of it. ~2s
+  // standalone, past 5000ms under the full 313-file run.
+  }, 30_000)
 })

--- a/packages/ts-cloud/src/deploy/dashboard-source.integration.test.ts
+++ b/packages/ts-cloud/src/deploy/dashboard-source.integration.test.ts
@@ -175,5 +175,9 @@ describe('dashboard source connection integration', () => {
       })
     ).json()) as any
     expect(disconnected.connection).toMatchObject({ status: 'disconnected', credentialConfigured: false })
-  })
+  // 30s, not the 5000ms default. Booting the dashboard spawns a real
+  // `stx build --no-cache` of the cockpit (~1.7s measured) before this test
+  // connects a repository and enqueues a signed deployment. ~2s standalone,
+  // past 5000ms under the full 313-file run.
+  }, 30_000)
 })


### PR DESCRIPTION
Three integration tests fail on CI, all the same way:

```
(fail) dashboard application onboarding integration ... [5000.72ms]
(fail) dashboard configuration integration ...         [5000.59ms]
(fail) dashboard source connection integration ...     [5000.58ms]
  ^ this test timed out after 5000ms.
```

## Why

They pass standalone at ~2s each. The cost is not the test body. Starting the dashboard spawns a real `stx build --no-cache` of the cockpit. Measured on the source connection test:

```
mkdtemp            2ms
hashPassword      51ms
saveUsers          0ms
startDashboard  1756ms      <-- buildLiveUi spawns the stx build
POST /api/login  155ms
```

Ten dashboard integration files each pay that. Under the full 313-file run the contention pushes these three past the 5000ms default.

They are also the only three dashboard integration tests with **no explicit timeout**. Every sibling already has one:

| file | timeout |
|---|---|
| backups | 15_000 |
| data-services | 15_000 |
| jobs | 10_000 |
| oidc | 20_000 |
| queue-worker | 10_000 |
| release | 10_000 |
| security | 30_000 |
| **configuration** | **none** |
| **onboarding** | **none** |
| **source** | **none** |

`dashboard-security` documents this exact failure in a comment: *"runs in ~3s locally but measured 5013ms on CI - flaking the whole pipeline on a 13ms margin."* This applies that same fix to the three that were missed.

## What I tried first

Skipping the live UI build in tests, via a `liveUi` option defaulting off under `NODE_ENV=test`, matching the existing `queueWorker` and `spendLoop` flags. That does not work: in a source checkout the live build is the only UI root there is. The packaged UI needs `bun run build`, so with the build disabled `startLocalDashboardServer` throws `ts-cloud dashboard UI not found` and all ten fail instead of three. Reverted.

Making the boot cheaper still looks worthwhile, since ~1.7s per dashboard boot is most of the runtime of ten test files. But that is a change to how the dashboard boots, not a test fix, so it does not belong in the same change as unbreaking CI.

## Verification

Full suite after the change: **4117 pass, 0 fail** (12 skip, 2 todo).