### PR TITLE
fix(fleet): carry the on-box database when a site moves

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -202,6 +202,37 @@ command. Background units are enabled but not started on the target until the
 source is drained, so the two boxes can never both run a scheduler against one
 dataset.
 
+#### The database
+
+A **SQLite** database rides along in the tree: it lives under `shared/`, which is
+the whole point of `sharedPaths`. An **external** database (RDS, a managed host)
+needs nothing either — the target reaches the same endpoint the source did.
+
+An **on-box Postgres or MySQL** database is different. It lives in the engine's
+own data directory, which belongs to the box rather than to the site, so the move
+carries it explicitly: dump on the source while background work is stopped, carry
+the file, then create the role and database on the target and load it — using the
+same dump, setup, and restore scripts `cloud db:backup`/`db:restore` and
+provisioning use, so a moved database is built exactly like a provisioned one.
+
+The dump is loaded **before** the app starts on the target, so its first request
+finds its data.
+
+Two rules keep this safe:
+
+- If the project has an on-box database and the move has no way to carry it, the
+  move **refuses to run**. Moving the tree alone would pass every check in the
+  plan — the app starts, answers its health gate, takes the DNS cutover — and
+  then serve production an empty database.
+- If the target already has a database of that name **with tables in it**, the
+  move refuses. Loading a dump over someone else's data is the one genuinely
+  destructive thing this operation could do, so it is a precondition the operator
+  resolves rather than a step behind a confirmation flag.
+
+Like the tree snapshot, the dump is re-taken on a resume rather than skipped: one
+from an earlier attempt predates whatever the source has committed since, and
+shipping stale rows is worse than dumping twice.
+
 The archive travels through the machine running the command rather than directly
 between the boxes: a direct hop would need the target to hold a credential for
 the source, which is the same credential-radius problem consolidation already

--- a/packages/ts-cloud/bin/commands/site.ts
+++ b/packages/ts-cloud/bin/commands/site.ts
@@ -5,11 +5,15 @@ import type { SiteMoveEffects } from '../../src/operations/site-move'
 import { existsSync } from 'node:fs'
 import { readFile, writeFile } from 'node:fs/promises'
 import * as cli from '../../src/utils/cli'
+import { resolveAppDatabase } from '@ts-cloud/core'
 import { initializeDashboardControlPlane } from '../../src/deploy/dashboard-control-plane'
 import { createDnsProvider } from '../../src/dns'
 import { normalizePublicIpv6, reconcileAddressRecords, verifyAddressRecord } from '../../src/deploy/server-dns'
 import { addSiteToCloudConfig } from '../../src/deploy/site-config-editor'
 import { siteInstallBase } from '../../src/deploy/site-target'
+import { buildBackupScript } from '../../src/deploy/dashboard-database'
+import { buildDatabaseSetupScript, isLocalDatabase } from '../../src/drivers/shared/db-provision'
+import { buildBackupRestoreScript } from '../../src/drivers/shared/backups'
 import { buildRpxConfig, buildRpxFragmentRefreshScript } from '../../src/drivers/shared/rpx-gateway'
 import { FleetStore, SystemFleetSshTransport } from '../../src/fleet'
 import { applyPlan, formatPlan, resolvePlan } from '../../src/operations/plan'
@@ -114,6 +118,16 @@ async function runSiteMove(siteName: string, options: SiteMoveCommandOptions): P
     const zoneFor = (fqdn: string): string =>
       configuredZone && fqdn.endsWith(configuredZone) ? configuredZone : fqdn.split('.').slice(-2).join('.')
 
+    // An ON-BOX engine database has to be carried separately: it lives in the
+    // engine's data directory, not in the site tree. An external one needs
+    // nothing — the target reaches the same endpoint the source did. SQLite
+    // needs nothing either; it is under `shared/` and rides along in the tree.
+    const appDatabase = resolveAppDatabase(config)
+    const onBoxDatabase =
+      appDatabase?.name && isLocalDatabase(appDatabase) ? { name: appDatabase.name } : undefined
+    const dumpPath = `/tmp/ts-cloud-move-${slug}-${siteName}.sql.gz`
+    const engine = (appDatabase?.engine ?? 'mysql') as 'mysql' | 'mariadb' | 'postgres'
+
     const effects: SiteMoveEffects = {
       runOnSource: (script) => execOn(transport, source, script),
       runOnTarget: (script) => execOn(transport, target, script),
@@ -165,6 +179,60 @@ async function runSiteMove(siteName: string, options: SiteMoveCommandOptions): P
         )
         return published ? target.endpoint : undefined
       },
+      ...(onBoxDatabase
+        ? {
+            database: {
+              // The SAME dump the backup command takes, written to a known path
+              // so the transfer and the restore can find it without parsing.
+              dump: async () => {
+                await execOn(
+                  transport,
+                  source,
+                  [
+                    'set -euo pipefail',
+                    'eval "$(cd /opt/pantry && pantry env 2>/dev/null)" || true',
+                    ...buildBackupScript(engine, onBoxDatabase.name, '/tmp', appDatabase),
+                    `mv -f "$(ls -1t /tmp/${onBoxDatabase.name}-*.sql.gz | head -1)" ${dumpPath}`,
+                  ].join('\n'),
+                )
+              },
+              dumpStaged: async () => {
+                const result = await transport.exec(target, `test -s ${dumpPath} && echo staged || true`)
+                return result.stdout.includes('staged')
+              },
+              transferDump: async () => {
+                const local = `${process.cwd()}/.ts-cloud-move-${slug}-${siteName}.sql.gz`
+                await copyFile(source, `${source.sshUser}@${source.endpoint}:${dumpPath}`, local)
+                await copyFile(target, local, `${target.sshUser}@${target.endpoint}:${dumpPath}`)
+                await Bun.file(local).delete().catch(() => {})
+              },
+              restore: async () => {
+                await execOn(
+                  transport,
+                  target,
+                  [
+                    // Create the role + database first, with the SAME idempotent
+                    // script provisioning runs, then load the dump into it.
+                    ...buildDatabaseSetupScript(appDatabase, config.infrastructure?.compute?.managedServices ?? {}),
+                    ...buildBackupRestoreScript(appDatabase, { from: dumpPath }),
+                    `rm -f ${dumpPath}`,
+                  ].join('\n'),
+                )
+              },
+              targetHasData: async () => {
+                const query =
+                  engine === 'postgres'
+                    ? `psql -tAc "select count(*) from information_schema.tables where table_schema='public'" -d ${onBoxDatabase.name} 2>/dev/null || echo 0`
+                    : `mysql -N -B -e "select count(*) from information_schema.tables where table_schema='${onBoxDatabase.name}'" 2>/dev/null || echo 0`
+                const result = await transport.exec(
+                  target,
+                  `eval "$(cd /opt/pantry && pantry env 2>/dev/null)" || true\n${query}`,
+                )
+                return Number.parseInt(result.stdout.trim().split('\n').pop() ?? '0', 10) > 0
+              },
+            },
+          }
+        : {}),
       cutoverDns: async () => {
         if (!domain) return []
         if (!dnsName) return [`No DNS provider configured — point ${domain} at ${target.endpoint} manually.`]
@@ -191,6 +259,7 @@ async function runSiteMove(siteName: string, options: SiteMoveCommandOptions): P
         targetAddress: target.endpoint,
         port: site.port,
         healthCheckPath: site.healthCheck?.path,
+        database: onBoxDatabase,
       },
       effects,
     )

--- a/packages/ts-cloud/src/operations/site-move.test.ts
+++ b/packages/ts-cloud/src/operations/site-move.test.ts
@@ -285,3 +285,101 @@ describe('remote scripts', () => {
     expect(siteMoveArchivePath('hq', 'bughq')).toBe('/tmp/ts-cloud-move-hq-bughq.tar.gz')
   })
 })
+
+/**
+ * A SQLite database rides along in the tree — it lives under `shared/`, which is
+ * the whole point of `sharedPaths`. A Postgres or MySQL database does not: it
+ * lives in the engine's own data directory, which belongs to the box rather than
+ * the site. Moving the tree alone would pass every check in the plan and then
+ * serve production an empty database.
+ */
+describe('planSiteMove with an on-box database', () => {
+  function dbWorld() {
+    const base = world()
+    const db = { dumped: false, staged: false, restored: false, targetData: false }
+    const effects = {
+      ...base.effects,
+      database: {
+        dump: async () => { db.dumped = true },
+        transferDump: async () => { db.staged = true },
+        dumpStaged: async () => db.staged,
+        restore: async () => { db.restored = true },
+        targetHasData: async () => db.targetData,
+      },
+    }
+    return { state: base.state, db, effects }
+  }
+
+  const withDb = { ...options, database: { name: 'bughq' } }
+
+  it('refuses the move when there is no way to carry the database', async () => {
+    await expect(planSiteMove(withDb, world().effects)).rejects.toThrow('no way to carry it')
+  })
+
+  /** Loading a dump over data already there is the one destructive thing here. */
+  it('refuses when the target already holds a database of that name', async () => {
+    const { db, effects } = dbWorld()
+    db.targetData = true
+    await expect(planSiteMove(withDb, effects)).rejects.toThrow('already has a database')
+  })
+
+  it('carries the database, and loads it before the app starts', async () => {
+    const p = await planSiteMove(withDb, dbWorld().effects)
+    const ids = p.steps.map(step => step.id)
+    expect(ids).toEqual([
+      'pause-workers',
+      'database-dump',
+      'snapshot',
+      'transfer',
+      'database-transfer',
+      'database-restore',
+      'restore',
+      'health',
+      'gateway',
+      'dns',
+      'drain-source',
+    ])
+    // The dump is taken while background work is stopped, and loaded before the
+    // app on the target can serve a request against it.
+    expect(ids.indexOf('database-dump')).toBeGreaterThan(ids.indexOf('pause-workers'))
+    expect(ids.indexOf('database-restore')).toBeLessThan(ids.indexOf('restore'))
+  })
+
+  it('moves the data end to end', async () => {
+    const { state, db, effects } = dbWorld()
+    const p = await planSiteMove(withDb, effects)
+    expect((await applyPlan(p, await resolvePlan(p))).success).toBe(true)
+    expect(db).toMatchObject({ dumped: true, staged: true, restored: true })
+    expect(state.sourceRunning).toBe(false)
+  })
+
+  /** A dump from an earlier attempt predates what the source has committed since. */
+  it('re-dumps on a resume rather than shipping stale rows', async () => {
+    const { effects } = dbWorld()
+    const p = await planSiteMove(withDb, effects)
+    await applyPlan(p, await resolvePlan(p))
+    const again = await resolvePlan(await planSiteMove(withDb, effects))
+    expect(again.find(item => item.step.id === 'database-dump')?.state).toBe('pending')
+    // The transfer, though, resumes — the dump is already staged.
+    expect(again.find(item => item.step.id === 'database-transfer')?.state).toBe('satisfied')
+  })
+
+  /** An external database is reached at the same endpoint from either box. */
+  it('adds no database steps when the project has no on-box database', async () => {
+    const p = await planSiteMove(options, world().effects)
+    expect(p.steps.map(step => step.id).some(id => id.startsWith('database-'))).toBe(false)
+  })
+
+  it('leaves the source serving when the restore fails', async () => {
+    const { state, effects } = dbWorld()
+    const p = await planSiteMove(withDb, {
+      ...effects,
+      database: { ...effects.database, restore: async () => { throw new Error('role does not exist') } },
+    })
+    const outcome = await applyPlan(p, await resolvePlan(p))
+    expect(outcome.success).toBe(false)
+    expect(outcome.steps.at(-1)?.id).toBe('database-restore')
+    expect(state.published).toBe('203.0.113.1')
+    expect(state.sourceRunning).toBe(true)
+  })
+})

--- a/packages/ts-cloud/src/operations/site-move.ts
+++ b/packages/ts-cloud/src/operations/site-move.ts
@@ -243,6 +243,41 @@ export interface SiteMoveEffects {
   refreshTargetGateway: () => Promise<void>
   /** Does the target's gateway already route this site? */
   targetRoutesSite: () => Promise<boolean>
+  /**
+   * How to carry an ON-BOX database, when the project has one.
+   *
+   * A SQLite database rides along in the tree already — it lives under
+   * `shared/`, which is the whole point of `sharedPaths`. An engine database
+   * does not: Postgres and MySQL keep their data in the engine's own directory,
+   * which belongs to the box rather than to the site. Moving the tree and not
+   * the database would cut DNS over to a target serving an empty app, so the
+   * plan REFUSES to be built when a project has one of these and no way to
+   * carry it — see {@link SiteMoveOptions.database}.
+   *
+   * Absent when the database is external (RDS, a managed host): the target
+   * connects to the same endpoint the source did, and there is nothing to move.
+   */
+  database?: SiteMoveDatabaseEffects
+}
+
+/** Carrying an on-box engine database between boxes, in resumable pieces. */
+export interface SiteMoveDatabaseEffects {
+  /** Dump it on the source. */
+  dump: () => Promise<void>
+  /** Carry the dump to the target. */
+  transferDump: () => Promise<void>
+  /** Is the dump already staged on the target? Lets the transfer resume. */
+  dumpStaged: () => Promise<boolean>
+  /** Create the role + database on the target, then load the dump into it. */
+  restore: () => Promise<void>
+  /**
+   * Does the target ALREADY hold a database of this name with tables in it?
+   *
+   * Checked as a precondition, not as a step: loading a dump over someone
+   * else's data is the one genuinely destructive thing a move could do, and the
+   * answer decides whether the operation may run at all.
+   */
+  targetHasData: () => Promise<boolean>
 }
 
 export interface SiteMoveOptions {
@@ -259,6 +294,13 @@ export interface SiteMoveOptions {
   port?: number
   /** Health-check path, defaulting to `/`. */
   healthCheckPath?: string
+  /**
+   * The on-box engine database this site's project owns, when it has one —
+   * `resolveAppDatabase(config)` narrowed by `isLocalDatabase`. Naming it here
+   * is what makes the move refuse to run without a way to carry it, rather than
+   * moving the app and quietly leaving its data behind.
+   */
+  database?: { name: string }
 }
 
 /**
@@ -273,6 +315,27 @@ export async function planSiteMove(options: SiteMoveOptions, effects: SiteMoveEf
 
   if (from === to) throw new Error(`'${siteName}' is already on ${to}.`)
 
+  // A project with an on-box engine database and no way to carry it must not
+  // move at all. Moving the tree alone would pass every check in this plan —
+  // the app starts, answers its health gate, takes the DNS cutover — and serve
+  // an empty database to production. Refusing here is the only honest answer.
+  if (options.database && !effects.database)
+    throw new Error(
+      `'${siteName}' uses the on-box database '${options.database.name}', which lives in the engine's own `
+      + 'data directory rather than in the site tree, and this move has no way to carry it. '
+      + 'Moving the site without it would cut traffic over to an empty database.',
+    )
+
+  // Loading a dump over data already on the target is the one genuinely
+  // destructive thing this operation could do, so it is a precondition something
+  // the operator resolves, not a step with a confirmation flag on it.
+  if (options.database && effects.database && (await effects.database.targetHasData()))
+    throw new Error(
+      `${to} already has a database named '${options.database.name}' with tables in it. `
+      + 'Restoring this site\'s dump over it would destroy that data. '
+      + 'Rename or drop it on the target first, or point this project at a different database name.',
+    )
+
   const steps: OperationStep[] = [
     {
       id: 'pause-workers',
@@ -282,6 +345,20 @@ export async function planSiteMove(options: SiteMoveOptions, effects: SiteMoveEf
         await effects.runOnSource(buildPauseWorkersScript(slug, siteName))
       },
     },
+    ...(effects.database
+      ? [
+          {
+            id: 'database-dump',
+            title: `Dump the '${options.database?.name}' database on ${from}`,
+            // Never skipped, for the same reason the tree snapshot is not: a
+            // dump from an earlier attempt predates whatever the source has
+            // committed since, and shipping stale rows is worse than dumping
+            // twice.
+            satisfied: async () => false,
+            apply: () => effects.database!.dump(),
+          } satisfies OperationStep,
+        ]
+      : []),
     {
       id: 'snapshot',
       title: `Archive the site's tree and units on ${from}`,
@@ -301,6 +378,26 @@ export async function planSiteMove(options: SiteMoveOptions, effects: SiteMoveEf
       satisfied: () => effects.archiveStaged(),
       apply: () => effects.transferArchive(),
     },
+    ...(effects.database
+      ? [
+          {
+            id: 'database-transfer',
+            title: `Carry the database dump to ${to}`,
+            change: { from, to },
+            satisfied: () => effects.database!.dumpStaged(),
+            apply: () => effects.database!.transferDump(),
+          } satisfies OperationStep,
+          {
+            id: 'database-restore',
+            title: `Create and load '${options.database?.name}' on ${to}`,
+            // Before the app starts, so its first request finds its data —
+            // and never skipped, because the precondition above already
+            // established the target holds nothing this could overwrite.
+            satisfied: async () => false,
+            apply: () => effects.database!.restore(),
+          } satisfies OperationStep,
+        ]
+      : []),
     {
       id: 'restore',
       title: `Unpack the site on ${to} and start it`,


### PR DESCRIPTION
Follow-up to #176. Refs #167.

## The hole

`site:move` moved the site's tree and left an on-box engine database behind.

- A **SQLite** database rides along already — it lives under `shared/`, which is the whole point of `sharedPaths`.
- An **external** database (RDS, a managed host) needs nothing — the target reaches the same endpoint the source did.
- An **on-box Postgres or MySQL** database is neither. Its data lives in the engine's own directory, which belongs to the *box* rather than to the site.

So the move passed every check it had and was still wrong. The app started on the target, answered its health gate on loopback, took the DNS cutover — and served production an empty database, with the real rows still sitting on a box the operator was about to delete. Nothing in the plan could have caught it, because every signal it looks at was green.

## The fix

The database is carried explicitly, as three resumable steps folded into the existing plan:

```
pause-workers → database-dump → snapshot → transfer → database-transfer
  → database-restore → restore → health → gateway → dns → drain-source
```

The dump is taken while background work is stopped, so it is consistent for the same reason the tree snapshot is. It is loaded **before** the app starts on the target, so the app's first request finds its data.

Every part of it is a script something else already uses — `buildBackupScript` for the dump, `buildDatabaseSetupScript` for the role and schema, `buildBackupRestoreScript` for the load — so a moved database is built exactly like a provisioned one rather than by a second mechanism that drifts.

## Two preconditions, not steps

Both are answers only the operator can give, so they refuse to build a plan rather than appearing as a step with a flag on it:

- **A project with an on-box database and no way to carry it refuses to move at all.** Moving half an application is worse than not moving it.
- **A target that already holds a database of that name *with tables in it* refuses too.** Loading a dump over live data is the one genuinely destructive thing this operation could do, and a `--confirm` flag is the wrong shape for "you are about to overwrite someone else's database" — rename or drop it first, or point the project at a different name.

The dump is re-taken on a resume, for the same reason the tree snapshot is: one from an earlier attempt predates whatever the source has committed since, and shipping stale rows is worse than dumping twice. The *transfer* still resumes normally.

## Verification

`bun test` — 4124 pass, 0 fail. Typecheck and lint clean.

7 new cases: the refusal with no carrier, the refusal when the target holds data, step ordering (dump after the pause, restore before the app starts), end-to-end movement, re-dumping on resume while the transfer skips, no database steps at all for an external database, and the source left serving when the restore fails.

Standing caveat from #176, now more pointed: this has been exercised at the unit level with injected effects, **not against two live boxes**. The remote scripts and the scp hops still deserve a rehearsal on throwaway servers before the first real production move.
