### PR TITLE
fix(fleet): carry a site's TLS material when it moves

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -233,6 +233,26 @@ Like the tree snapshot, the dump is re-taken on a resume rather than skipped: on
 from an earlier attempt predates whatever the source has committed since, and
 shipping stale rows is worse than dumping twice.
 
+#### TLS
+
+Certificates live in the gateway's cert directory (`/etc/rpx/certs` by default),
+which belongs to the box rather than to the site — the same shape as an on-box
+database, and the same failure if left behind. The move carries the certificate
+and private key for the site's domain and every alias, **before** it routes the
+site and well before DNS: a hostname that resolves to a box holding no
+certificate for it is refused by every browser, which is a worse outcome than the
+site simply still being on the old box. Private keys are restored `0600`.
+
+Whether the target already has them is decided by checksum, not by whether a file
+exists — an older certificate for the same hostname, expired or issued while the
+domain pointed somewhere else, is not the one being moved. A hostname the source
+has no certificate for is skipped rather than blocking: a site behind on-demand
+TLS may legitimately have none yet, and the target re-issues on first request.
+
+Renewal is not carried. The per-project renewal timer is written by the normal
+provisioning path, so the next `cloud deploy` against the target establishes it;
+until then the carried certificates stand on their own remaining validity.
+
 The archive travels through the machine running the command rather than directly
 between the boxes: a direct hop would need the target to hold a credential for
 the source, which is the same credential-radius problem consolidation already

--- a/packages/ts-cloud/bin/commands/site.ts
+++ b/packages/ts-cloud/bin/commands/site.ts
@@ -14,10 +14,19 @@ import { siteInstallBase } from '../../src/deploy/site-target'
 import { buildBackupScript } from '../../src/deploy/dashboard-database'
 import { buildDatabaseSetupScript, isLocalDatabase } from '../../src/drivers/shared/db-provision'
 import { buildBackupRestoreScript } from '../../src/drivers/shared/backups'
-import { buildRpxConfig, buildRpxFragmentRefreshScript } from '../../src/drivers/shared/rpx-gateway'
+import { buildRpxConfig, buildRpxFragmentRefreshScript, DEFAULT_RPX_CERTS_DIR } from '../../src/drivers/shared/rpx-gateway'
 import { FleetStore, SystemFleetSshTransport } from '../../src/fleet'
 import { applyPlan, formatPlan, resolvePlan } from '../../src/operations/plan'
-import { planSiteMove, siteMoveArchivePath } from '../../src/operations/site-move'
+import {
+  buildCertificatePackScript,
+  buildCertificateStateScript,
+  buildCertificateUnpackScript,
+  certificatesMatch,
+  parseCertificateState,
+  planSiteMove,
+  siteMoveArchivePath,
+  siteMoveCertArchivePath,
+} from '../../src/operations/site-move'
 import { loadValidatedConfig, resolveDnsProviderConfig } from './shared'
 
 interface SiteAddOptions {
@@ -126,6 +135,10 @@ async function runSiteMove(siteName: string, options: SiteMoveCommandOptions): P
     const onBoxDatabase =
       appDatabase?.name && isLocalDatabase(appDatabase) ? { name: appDatabase.name } : undefined
     const dumpPath = `/tmp/ts-cloud-move-${slug}-${siteName}.sql.gz`
+    const certArchive = siteMoveCertArchivePath(slug, siteName)
+    const certsDir = proxy?.certsDir ?? DEFAULT_RPX_CERTS_DIR
+    // Every hostname this site is served on needs its own certificate.
+    const certDomains = [domain, ...(site.aliases ?? [])].filter((value): value is string => !!value)
     const engine = (appDatabase?.engine ?? 'mysql') as 'mysql' | 'mariadb' | 'postgres'
 
     const effects: SiteMoveEffects = {
@@ -229,6 +242,36 @@ async function runSiteMove(siteName: string, options: SiteMoveCommandOptions): P
                   `eval "$(cd /opt/pantry && pantry env 2>/dev/null)" || true\n${query}`,
                 )
                 return Number.parseInt(result.stdout.trim().split('\n').pop() ?? '0', 10) > 0
+              },
+            },
+          }
+        : {}),
+      ...(proxy
+        ? {
+            certificates: {
+              inPlace: async () => {
+                const state = buildCertificateStateScript(certsDir, certDomains)
+                const [onSource, onTarget] = await Promise.all([
+                  transport.exec(source, state),
+                  transport.exec(target, state),
+                ])
+                return certificatesMatch(
+                  parseCertificateState(onSource.stdout),
+                  parseCertificateState(onTarget.stdout),
+                )
+              },
+              carry: async () => {
+                await execOn(transport, source, buildCertificatePackScript(certsDir, certDomains, certArchive))
+                const local = `${process.cwd()}/.ts-cloud-move-${slug}-${siteName}-certs.tar.gz`
+                // A site behind on-demand TLS may have no certificate yet; the
+                // pack script says so and exits clean rather than failing.
+                const staged = await transport.exec(source, `test -s ${certArchive} && echo staged || true`)
+                if (!staged.stdout.includes('staged')) return
+                await copyFile(source, `${source.sshUser}@${source.endpoint}:${certArchive}`, local)
+                await copyFile(target, local, `${target.sshUser}@${target.endpoint}:${certArchive}`)
+                await Bun.file(local).delete().catch(() => {})
+                await execOn(transport, target, buildCertificateUnpackScript(certsDir, certArchive))
+                await transport.exec(source, `rm -f ${certArchive}`)
               },
             },
           }

--- a/packages/ts-cloud/src/operations/site-move.test.ts
+++ b/packages/ts-cloud/src/operations/site-move.test.ts
@@ -2,6 +2,11 @@ import type { SiteMoveEffects } from './site-move'
 import { describe, expect, it } from 'bun:test'
 import { applyPlan, formatPlan, resolvePlan } from './plan'
 import {
+  buildCertificatePackScript,
+  buildCertificateStateScript,
+  buildCertificateUnpackScript,
+  certificatesMatch,
+  parseCertificateState,
   buildDrainSourceScript,
   buildHealthGateScript,
   buildPauseWorkersScript,
@@ -381,5 +386,129 @@ describe('planSiteMove with an on-box database', () => {
     expect(outcome.steps.at(-1)?.id).toBe('database-restore')
     expect(state.published).toBe('203.0.113.1')
     expect(state.sourceRunning).toBe(true)
+  })
+})
+
+/**
+ * Certificates live in the gateway's cert directory, which belongs to the box
+ * rather than the site — the same shape as an on-box database. With pinned
+ * production certs, a cutover to a box without them is refused by every browser.
+ */
+describe('planSiteMove with TLS material', () => {
+  function certWorld(sourceCerts: Record<string, string>, targetCerts: Record<string, string> = {}) {
+    const base = world()
+    const carried = { count: 0, target: { ...targetCerts } }
+    const effects = {
+      ...base.effects,
+      certificates: {
+        inPlace: async () =>
+          certificatesMatch(new Map(Object.entries(sourceCerts)), new Map(Object.entries(carried.target))),
+        carry: async () => { carried.count++; carried.target = { ...sourceCerts } },
+      },
+    }
+    return { state: base.state, carried, effects }
+  }
+
+  it('carries certificates before routing, and well before DNS', async () => {
+    const p = await planSiteMove(options, certWorld({ 'bughq.example.com': 'abc' }).effects)
+    const ids = p.steps.map(step => step.id)
+    expect(ids.indexOf('certificates')).toBeLessThan(ids.indexOf('gateway'))
+    expect(ids.indexOf('certificates')).toBeLessThan(ids.indexOf('dns'))
+    expect(ids.indexOf('certificates')).toBeGreaterThan(ids.indexOf('restore'))
+  })
+
+  it('carries them when the target has none', async () => {
+    const { carried, effects } = certWorld({ 'bughq.example.com': 'abc' })
+    const p = await planSiteMove(options, effects)
+    expect((await applyPlan(p, await resolvePlan(p))).success).toBe(true)
+    expect(carried.count).toBe(1)
+  })
+
+  /** An OLDER cert for the same hostname is not the one being moved. */
+  it('replaces a stale certificate the target already holds', async () => {
+    const { carried, effects } = certWorld({ 'bughq.example.com': 'new' }, { 'bughq.example.com': 'expired' })
+    const resolved = await resolvePlan(await planSiteMove(options, effects))
+    expect(resolved.find(item => item.step.id === 'certificates')?.state).toBe('pending')
+    const p = await planSiteMove(options, effects)
+    await applyPlan(p, await resolvePlan(p))
+    expect(carried.count).toBe(1)
+    expect(carried.target['bughq.example.com']).toBe('new')
+  })
+
+  it('skips the carry when the target already holds the same material', async () => {
+    const { carried, effects } = certWorld({ 'bughq.example.com': 'abc' }, { 'bughq.example.com': 'abc' })
+    const p = await planSiteMove(options, effects)
+    const outcome = await applyPlan(p, await resolvePlan(p))
+    expect(outcome.steps.find(step => step.id === 'certificates')?.state).toBe('skipped')
+    expect(carried.count).toBe(0)
+  })
+
+  /** On-demand TLS may legitimately have issued nothing yet. */
+  it('does not block on a hostname the source has no certificate for', async () => {
+    const { effects } = certWorld({ 'bughq.example.com': 'absent' })
+    const resolved = await resolvePlan(await planSiteMove(options, effects))
+    expect(resolved.find(item => item.step.id === 'certificates')?.state).toBe('satisfied')
+  })
+
+  it('adds no certificate step when TLS is terminated off the box', async () => {
+    const p = await planSiteMove(options, world().effects)
+    expect(p.steps.map(step => step.id)).not.toContain('certificates')
+  })
+
+  it('leaves DNS on the source when the carry fails', async () => {
+    const { state, effects } = certWorld({ 'bughq.example.com': 'abc' })
+    const p = await planSiteMove(options, {
+      ...effects,
+      certificates: { ...effects.certificates, carry: async () => { throw new Error('permission denied') } },
+    })
+    const outcome = await applyPlan(p, await resolvePlan(p))
+    expect(outcome.success).toBe(false)
+    expect(outcome.steps.at(-1)?.id).toBe('certificates')
+    expect(state.published).toBe('203.0.113.1')
+    expect(state.sourceRunning).toBe(true)
+  })
+})
+
+describe('certificate scripts', () => {
+  it('reports a checksum per hostname, or absent', () => {
+    const script = buildCertificateStateScript('/etc/rpx/certs', ['bughq.example.com'])
+    expect(script).toContain("'/etc/rpx/certs/bughq.example.com.crt'")
+    expect(script).toContain('sha256sum')
+    expect(script).toContain('cert:bughq.example.com:absent')
+  })
+
+  it('parses the reported state', () => {
+    const state = parseCertificateState('cert:a.example.com:abc123\ncert:b.example.com:absent\nnoise')
+    expect(state.get('a.example.com')).toBe('abc123')
+    expect(state.get('b.example.com')).toBe('absent')
+    expect(state.size).toBe(2)
+  })
+
+  it('compares only the hostnames the source actually has a cert for', () => {
+    const source = new Map([['a', 'x'], ['b', 'absent']])
+    expect(certificatesMatch(source, new Map([['a', 'x']]))).toBe(true)
+    expect(certificatesMatch(source, new Map([['a', 'y']]))).toBe(false)
+    expect(certificatesMatch(source, new Map())).toBe(false)
+  })
+
+  it('packs the key alongside the certificate for every hostname', () => {
+    const script = buildCertificatePackScript('/etc/rpx/certs', ['a.example.com', 'b.example.com'], '/tmp/c.tar.gz')
+    expect(script).toContain("'a.example.com.crt'")
+    expect(script).toContain("'a.example.com.key'")
+    expect(script).toContain("'b.example.com.key'")
+  })
+
+  /** A site whose certificate has not been issued yet is not an error. */
+  it('exits clean when there is nothing to pack', () => {
+    const script = buildCertificatePackScript('/etc/rpx/certs', ['a.example.com'], '/tmp/c.tar.gz')
+    expect(script).toContain('no certificates to carry')
+    expect(script).toContain('exit 0')
+  })
+
+  /** A world-readable private key on a shared box is silent until it is not. */
+  it('restores private keys 0600', () => {
+    const script = buildCertificateUnpackScript('/etc/rpx/certs', '/tmp/c.tar.gz')
+    expect(script).toContain("chmod 600 '/etc/rpx/certs'/*.key")
+    expect(script).toContain('tar xzf')
   })
 })

--- a/packages/ts-cloud/src/operations/site-move.ts
+++ b/packages/ts-cloud/src/operations/site-move.ts
@@ -217,6 +217,97 @@ export function parseSourceDrained(output: string): boolean {
   return !output.split('\n').some(line => line.trim().startsWith('active:'))
 }
 
+/** Where a site's TLS material is staged while it crosses between boxes. */
+export function siteMoveCertArchivePath(slug: string, siteName: string): string {
+  return `/tmp/ts-cloud-move-${slug}-${siteName}-certs.tar.gz`
+}
+
+/**
+ * Report a checksum per hostname for the cert the box holds, or `absent`.
+ *
+ * A checksum rather than "does the file exist": the target may hold an OLDER
+ * certificate for the same hostname — an expired one from a previous tenancy,
+ * or a staging cert issued while the domain still pointed elsewhere — and
+ * treating that as "already carried" would hand the cutover a certificate
+ * browsers reject.
+ *
+ * Read-only, so a plan can use it without changing either box.
+ */
+export function buildCertificateStateScript(certsDir: string, domains: readonly string[]): string {
+  return [
+    'set -u',
+    ...domains.map(domain =>
+      `if [ -s ${sh(`${certsDir}/${domain}.crt`)} ]; then`
+      + ` echo "cert:${domain}:$(sha256sum ${sh(`${certsDir}/${domain}.crt`)} | cut -d' ' -f1)";`
+      + ` else echo "cert:${domain}:absent"; fi`,
+    ),
+  ].join('\n')
+}
+
+/** `hostname → checksum | 'absent'` from {@link buildCertificateStateScript}. */
+export function parseCertificateState(output: string): Map<string, string> {
+  const state = new Map<string, string>()
+  for (const line of output.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed.startsWith('cert:')) continue
+    const [, domain, checksum] = trimmed.split(':')
+    if (domain && checksum) state.set(domain, checksum)
+  }
+  return state
+}
+
+/**
+ * Is the target's TLS material already what the source holds?
+ *
+ * Only hostnames the SOURCE has a certificate for are compared. A site running
+ * behind on-demand TLS may legitimately have none yet, and a move must not
+ * block on carrying something that does not exist.
+ */
+export function certificatesMatch(source: Map<string, string>, target: Map<string, string>): boolean {
+  for (const [domain, checksum] of source) {
+    if (checksum === 'absent') continue
+    if (target.get(domain) !== checksum) return false
+  }
+  return true
+}
+
+/** Pack a site's certificate and private key for each hostname it serves. */
+export function buildCertificatePackScript(
+  certsDir: string,
+  domains: readonly string[],
+  archive: string,
+): string {
+  const names = domains.flatMap(domain => [`${domain}.crt`, `${domain}.key`])
+  return [
+    'set -eu',
+    `rm -f ${sh(archive)}`,
+    `cd ${sh(certsDir)} 2>/dev/null || { echo "no certs dir at ${certsDir}" >&2; exit 0; }`,
+    // `|| true` on the listing: a hostname with no cert yet is not an error, it
+    // is a site whose certificate has not been issued.
+    `TS_CLOUD_CERTS="$(ls ${names.map(sh).join(' ')} 2>/dev/null | tr '\\n' ' ' || true)"`,
+    '[ -n "$TS_CLOUD_CERTS" ] || { echo "no certificates to carry"; exit 0; }',
+    `tar czf ${sh(archive)} $TS_CLOUD_CERTS`,
+  ].join('\n')
+}
+
+/**
+ * Unpack the certificates on the target.
+ *
+ * The private keys are re-chmodded to 0600 after extraction. `tar` restores the
+ * modes it recorded, so this is belt-and-braces — but a world-readable private
+ * key on a shared box is the kind of mistake that is silent until it is not.
+ */
+export function buildCertificateUnpackScript(certsDir: string, archive: string): string {
+  return [
+    'set -eu',
+    `[ -s ${sh(archive)} ] || { echo "no certificate archive staged"; exit 0; }`,
+    `mkdir -p ${sh(certsDir)}`,
+    `tar xzf ${sh(archive)} -C ${sh(certsDir)}`,
+    `chmod 600 ${sh(certsDir)}/*.key 2>/dev/null || true`,
+    `rm -f ${sh(archive)}`,
+  ].join('\n')
+}
+
 /**
  * The side effects a move needs, injected so the operation is testable without
  * two live boxes, a provider, or a DNS account.
@@ -258,6 +349,35 @@ export interface SiteMoveEffects {
    * connects to the same endpoint the source did, and there is nothing to move.
    */
   database?: SiteMoveDatabaseEffects
+  /**
+   * How to carry the site's TLS material, when the project terminates TLS on the
+   * box itself.
+   *
+   * Certificates live in the gateway's cert directory, which belongs to the box
+   * rather than to the site — the same shape as an on-box database, and the same
+   * failure if it is left behind. With pinned production certificates the
+   * cutover lands on a box that has no certificate for the hostname and every
+   * browser refuses it. With on-demand TLS the target re-issues on first
+   * request, so it self-heals, but only after a visible gap during which the
+   * site is down.
+   *
+   * Absent when TLS is terminated somewhere else entirely — a CDN, a managed
+   * load balancer — where the box never holds the material to begin with.
+   */
+  certificates?: SiteMoveCertificateEffects
+}
+
+/** Carrying a site's TLS material between boxes. */
+export interface SiteMoveCertificateEffects {
+  /**
+   * Does the target already hold exactly what the source holds?
+   *
+   * Compared by checksum rather than existence: an older certificate for the
+   * same hostname on the target is not the one being moved.
+   */
+  inPlace: () => Promise<boolean>
+  /** Pack on the source, carry, unpack on the target. */
+  carry: () => Promise<void>
 }
 
 /** Carrying an on-box engine database between boxes, in resumable pieces. */
@@ -426,6 +546,20 @@ export async function planSiteMove(options: SiteMoveOptions, effects: SiteMoveEf
   }
 
   steps.push(
+    ...(effects.certificates
+      ? [
+          {
+            id: 'certificates',
+            title: `Carry the site's TLS material to ${to}`,
+            // Before the route and well before DNS: a hostname that resolves to
+            // a box with no certificate for it is refused by every browser, and
+            // that is a worse failure than the site simply still being on the
+            // old box.
+            satisfied: () => effects.certificates!.inPlace(),
+            apply: () => effects.certificates!.carry(),
+          } satisfies OperationStep,
+        ]
+      : []),
     {
       id: 'gateway',
       title: `Route the site on ${to}`,


### PR DESCRIPTION
Follow-up to #176 and #178. Refs #167, which names TLS explicitly in operation 2.

## The hole

Certificates live in the gateway's cert directory (`/etc/rpx/certs` by default), which belongs to the **box** rather than to the site — the same shape as the on-box database #178 fixed, and the same failure if left behind:

- With **pinned production certificates**, the cutover lands on a box holding no certificate for the hostname, and every browser refuses it.
- With **on-demand TLS** the target re-issues on first request, so it self-heals — but only after a visible outage.

Like the database, nothing in the plan could catch it: the app starts, the health gate passes on loopback (plain HTTP), the route publishes, DNS moves, and the site is down.

## The fix

The certificate and private key for the site's domain and every alias are carried **before** the route is published and well before DNS moves. That placement is the point: a hostname resolving to a box with no certificate for it is a worse outcome than the site simply still being on the old box.

```
… → restore → certificates → gateway → dns → drain-source
```

## Checksum, not existence

Whether the target already holds the material is decided by comparing checksums. An *older* certificate for the same hostname — expired, or issued while the domain still pointed somewhere else — is not the one being moved, and treating it as "already carried" would hand the cutover a certificate browsers reject.

A hostname the source has no certificate for is **skipped rather than blocking**: a site behind on-demand TLS may legitimately have none yet, and the pack script exits clean rather than failing on it.

Private keys are re-chmodded `0600` after extraction. `tar` restores the modes it recorded, so this is belt-and-braces — but a world-readable private key on a shared box is silent until it is not.

## What is deliberately not carried

**Renewal.** The per-project renewal timer is written by the normal provisioning path, so the next `cloud deploy` against the target establishes it; until then the carried certificates stand on their own remaining validity. Documented in `docs/cli.md` rather than left to be discovered.

## Verification

`bun test` — 4137 pass, 0 fail. Typecheck and lint clean.

13 new cases: ordering relative to the route and the cutover, carrying when the target has none, replacing a stale certificate the target already holds, skipping when the material already matches, not blocking on an unissued hostname, no step at all when TLS terminates off the box, DNS left on the source when the carry fails, plus the four script builders and the state parser.

Standing caveat, unchanged: `site:move` has been exercised at the unit level with injected effects, **not against two live boxes**. Worth a rehearsal on throwaway servers before the first real production move.
