### PR TITLE
feat(fleet): refuse to destroy a server still holding a moved site's rollback

### DIFF
--- a/packages/ts-cloud/bin/commands/compute-lifecycle.ts
+++ b/packages/ts-cloud/bin/commands/compute-lifecycle.ts
@@ -1,8 +1,64 @@
 import type { CLI } from '@stacksjs/clapp'
-import { resolveCloudProvider } from '@ts-cloud/core'
+import type { CloudDriver, EnvironmentType } from '@ts-cloud/core'
+import { resolveCloudProvider, resolveProjectStackName } from '@ts-cloud/core'
 import * as cli from '../../src/utils/cli'
 import { createCloudDriver } from '../../src/drivers'
+import { buildDrainedSiteScanScript, formatDrainedSiteRefusal, parseDrainedSites } from '../../src/operations/drained-sites'
 import { loadValidatedConfig } from './shared'
+
+/** The flag that authorizes discarding a drained site's files. */
+const DISCARD_FLAG = '--discard-drained-sites'
+
+/**
+ * Refuse a teardown that would take a moved site's rollback with it.
+ *
+ * Returns true when the destroy may proceed. Deliberately permissive about its
+ * own failure: a box that cannot be reached, or a driver that cannot run remote
+ * commands, produces a note rather than a block — this exists to stop a specific
+ * silent loss, not to stand between an operator and an unreachable server they
+ * are trying to get rid of.
+ */
+async function drainedSitesAllowTeardown(
+  driver: CloudDriver,
+  config: Awaited<ReturnType<typeof loadValidatedConfig>>,
+  environment: EnvironmentType,
+  discard: boolean,
+): Promise<boolean> {
+  if (discard) return true
+
+  const slug = config.project.slug
+  let output: string | undefined
+  try {
+    const targets = await driver.findComputeTargets({
+      slug,
+      environment,
+      role: 'app',
+      stackName: resolveProjectStackName(config, environment),
+    })
+    if (targets.length === 0) return true
+
+    const result = await driver.runRemoteDeploy({
+      targets,
+      commands: buildDrainedSiteScanScript(slug),
+      comment: `ts-cloud scan drained sites ${slug}`,
+      tags: { Project: slug, Environment: environment, Role: 'app' },
+    })
+    if (!result.success) {
+      cli.warn(`Could not check the server for moved-off site files: ${result.error || 'unknown error'}`)
+      return true
+    }
+    output = result.perInstance.map((instance) => instance.output ?? '').join('\n')
+  } catch (error) {
+    cli.warn(`Could not check the server for moved-off site files: ${error instanceof Error ? error.message : String(error)}`)
+    return true
+  }
+
+  const drained = parseDrainedSites(output)
+  if (drained.length === 0) return true
+
+  cli.error(formatDrainedSiteRefusal(drained, slug, DISCARD_FLAG))
+  return false
+}
 
 /**
  * Lifecycle commands for the lightweight single-server (Forge-style) compute
@@ -13,7 +69,8 @@ export function registerComputeLifecycleCommands(app: CLI): void {
     .command('destroy', 'Destroy the single-server compute (instance + firewall)')
     .option('--env <env>', 'Environment', { default: 'production' })
     .option('--force', 'Skip the confirmation prompt')
-    .action(async (options?: { env?: string; force?: boolean }) => {
+    .option('--discard-drained-sites', 'Destroy even though a moved site left its rollback files here')
+    .action(async (options?: { env?: string; force?: boolean; discardDrainedSites?: boolean }) => {
       cli.header('Destroy Compute')
       const config = await loadValidatedConfig()
       const environment = (options?.env || 'production') as 'production' | 'staging' | 'development'
@@ -28,6 +85,15 @@ export function registerComputeLifecycleCommands(app: CLI): void {
       cli.warn(
         `This terminates the ${provider} server for ${config.project.slug}/${environment} and deletes its firewall.`,
       )
+
+      // Checked BEFORE the prompt: an operator answering "yes" to a generic
+      // irreversibility warning has not been told that a moved site's rollback
+      // is sitting on this disk.
+      if (!(await drainedSitesAllowTeardown(driver, config, environment, !!options?.discardDrainedSites))) {
+        process.exitCode = 1
+        return
+      }
+
       if (!options?.force) {
         const ok = await cli.confirm('This is irreversible. Continue?', false)
         if (!ok) {

--- a/packages/ts-cloud/src/operations/drained-sites.test.ts
+++ b/packages/ts-cloud/src/operations/drained-sites.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'bun:test'
+import { buildDrainedSiteScanScript, formatDrainedSiteRefusal, parseDrainedSites } from './drained-sites'
+
+describe('buildDrainedSiteScanScript', () => {
+  it('scans this project\'s trees only', () => {
+    const script = buildDrainedSiteScanScript('hq').join('\n')
+    expect(script).toContain('/var/www/hq-*')
+    expect(script).toContain('^hq-$TS_CLOUD_SITE[-@.]')
+  })
+
+  /** A stray folder under /var/www must not block a teardown. */
+  it('counts only directories that hold a release tree', () => {
+    expect(buildDrainedSiteScanScript('hq').join('\n')).toContain('[ -d "$TS_CLOUD_DIR/releases" ] || continue')
+  })
+
+  /**
+   * A scan that could change the box would be a poor thing to run immediately
+   * before deciding whether to keep it.
+   */
+  it('only reads', () => {
+    const script = buildDrainedSiteScanScript('hq').join('\n')
+    for (const mutation of ['rm ', 'systemctl stop', 'systemctl start', 'systemctl disable', 'systemctl enable', 'mv ', 'tar ']) {
+      expect(script.includes(mutation)).toBe(false)
+    }
+    // Every redirect to a FILE goes to /dev/null (`>&1` duplicates a descriptor
+    // rather than writing anywhere), so nothing lands on disk.
+    for (const redirect of script.match(/>(?!&)\s*\S+/g) ?? []) {
+      expect(redirect.replace(/^>\s*/, '')).toBe('/dev/null')
+    }
+  })
+
+  it('escapes a slug with regex metacharacters', () => {
+    expect(buildDrainedSiteScanScript('my.app').join('\n')).toContain('^my\\.app-')
+  })
+
+  it('always exits 0, so a scan is never mistaken for a failure', () => {
+    expect(buildDrainedSiteScanScript('hq').at(-1)).toBe('exit 0')
+  })
+})
+
+describe('parseDrainedSites', () => {
+  it('reports the trees with nothing running for them', () => {
+    const drained = parseDrainedSites('site:bughq:no:1.2G\nsite:loghq:yes:800M')
+    expect(drained).toEqual([{ name: 'bughq', size: '1.2G' }])
+  })
+
+  /**
+   * A site with something active is a site on a box being torn down — ordinary,
+   * and already covered by the teardown's own confirmation.
+   */
+  it('ignores a site that is still running', () => {
+    expect(parseDrainedSites('site:bughq:yes:1.2G')).toEqual([])
+  })
+
+  it('is empty for a box with no trees, or no output at all', () => {
+    expect(parseDrainedSites('')).toEqual([])
+    expect(parseDrainedSites(undefined)).toEqual([])
+    expect(parseDrainedSites('some unrelated chatter')).toEqual([])
+  })
+
+  it('survives a missing size', () => {
+    expect(parseDrainedSites('site:bughq:no:')).toEqual([{ name: 'bughq', size: '?' }])
+  })
+})
+
+describe('formatDrainedSiteRefusal', () => {
+  it('names the sites, what the files are for, and the way forward', () => {
+    const message = formatDrainedSiteRefusal([{ name: 'bughq', size: '1.2G' }], 'hq', '--discard-drained-sites')
+    expect(message).toContain('hq-bughq (1.2G)')
+    expect(message).toContain('they are the rollback')
+    expect(message).toContain('--discard-drained-sites')
+  })
+
+  it('reads correctly for several', () => {
+    const message = formatDrainedSiteRefusal(
+      [{ name: 'a', size: '1G' }, { name: 'b', size: '2G' }],
+      'hq',
+      '--discard-drained-sites',
+    )
+    expect(message).toContain('2 site trees')
+    expect(message).toContain('for them')
+  })
+})

--- a/packages/ts-cloud/src/operations/drained-sites.ts
+++ b/packages/ts-cloud/src/operations/drained-sites.ts
@@ -1,0 +1,110 @@
+/**
+ * Detect sites whose files are still on a box that no longer serves them.
+ *
+ * `site:move` deliberately never deletes anything on the source: it stops the
+ * units, drops the gateway route, and leaves the whole tree in place. That
+ * leftover tree IS the rollback — the one thing that makes a bad cutover
+ * recoverable, and the reason the operation can promise reversibility "until the
+ * source server is destroyed".
+ *
+ * Which makes destroying that server the moment the promise expires, and nothing
+ * about the box says so. It has no running units for the site, so it looks idle;
+ * the config has moved on; the operator is tidying up. Terminating it is exactly
+ * the right thing to do once the move is verified, and exactly the wrong thing
+ * to do before — and those two look identical from outside.
+ *
+ * So: before a teardown, ask the box whether it is holding anyone's rollback.
+ *
+ * @see https://github.com/stacksjs/ts-cloud/issues/167
+ */
+
+/** Escape a value for safe use inside a POSIX ERE. */
+function reEscape(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/** Single-quote a value for safe embedding in the generated shell. */
+function sh(value: string): string {
+  return `'${value.split('\'').join('\'\\\'\'')}'`
+}
+
+/**
+ * Report every one of this project's site trees on the box and whether anything
+ * is still running for it.
+ *
+ * Read-only by construction — it lists and queries, and that is all. A scan that
+ * could change the box would be a poor thing to run immediately before deciding
+ * whether to keep it.
+ *
+ * A directory is only counted when it holds `releases/`, so a stray folder under
+ * `/var/www` is not mistaken for a deployed site and does not block a teardown
+ * the operator genuinely wants.
+ */
+export function buildDrainedSiteScanScript(slug: string, wwwRoot = '/var/www'): string[] {
+  const prefix = `${wwwRoot}/${slug}-`
+  return [
+    'set -u',
+    `for TS_CLOUD_DIR in ${prefix}*; do`,
+    '  [ -d "$TS_CLOUD_DIR" ] || continue',
+    // Only a real release tree counts as a deployed site.
+    '  [ -d "$TS_CLOUD_DIR/releases" ] || continue',
+    `  TS_CLOUD_SITE="\${TS_CLOUD_DIR#${prefix}}"`,
+    '  TS_CLOUD_ACTIVE=no',
+    `  for TS_CLOUD_UNIT in $(ls /etc/systemd/system/ 2>/dev/null | grep -E "^${reEscape(slug)}-$TS_CLOUD_SITE[-@.]" || true); do`,
+    '    systemctl is-active "$TS_CLOUD_UNIT" >/dev/null 2>&1 && TS_CLOUD_ACTIVE=yes',
+    '  done',
+    // Size is reported so the refusal can say how much is at stake.
+    '  TS_CLOUD_SIZE="$(du -sh "$TS_CLOUD_DIR" 2>/dev/null | cut -f1)"',
+    '  echo "site:$TS_CLOUD_SITE:$TS_CLOUD_ACTIVE:${TS_CLOUD_SIZE:-?}"',
+    'done',
+    'exit 0',
+  ]
+}
+
+export interface DrainedSite {
+  name: string
+  /** Human-readable size of the tree left behind, e.g. `1.2G`. */
+  size: string
+}
+
+/**
+ * Sites the box still holds but no longer runs.
+ *
+ * A site with something active is NOT drained — it is simply a site on a box
+ * being torn down, which is ordinary and already covered by the teardown's own
+ * confirmation. The interesting case is files with nothing running: either a
+ * completed `site:move` whose rollback this is, or a site that has been stopped
+ * and forgotten. Both are worth a sentence before the disk goes away.
+ */
+export function parseDrainedSites(output: string | undefined): DrainedSite[] {
+  if (!output) return []
+  const drained: DrainedSite[] = []
+  for (const line of output.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed.startsWith('site:')) continue
+    const [, name, active, size] = trimmed.split(':')
+    if (!name || active !== 'no') continue
+    drained.push({ name, size: size || '?' })
+  }
+  return drained
+}
+
+/**
+ * What the operator sees instead of a teardown.
+ *
+ * Names the sites, says what the files are FOR, and gives the two ways forward.
+ * The flag is deliberately its own thing rather than `--force`: `--force` exists
+ * so a teardown can run unattended, and a CI job that skips a prompt must not
+ * also silently discard the only copy of a rollback.
+ */
+export function formatDrainedSiteRefusal(sites: readonly DrainedSite[], slug: string, flag: string): string {
+  const list = sites.map(site => `  ${slug}-${site.name} (${site.size})`).join('\n')
+  const them = sites.length === 1 ? 'it' : 'them'
+  return (
+    `This server still holds ${sites.length} site tree${sites.length === 1 ? '' : 's'} with nothing running for `
+    + `${them}:\n${list}\n`
+    + 'A site moved off this box keeps its files here on purpose — they are the rollback, and they are what makes '
+    + 'the move reversible until this server is destroyed. Destroying it now discards that.\n'
+    + `Verify the site is serving from its new home first, then re-run with ${flag} to destroy it anyway.`
+  )
+}

--- a/packages/ts-cloud/test/integration/site-move-e2e.test.ts
+++ b/packages/ts-cloud/test/integration/site-move-e2e.test.ts
@@ -24,6 +24,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { buildDrainedSiteScanScript, parseDrainedSites } from '../../src/operations/drained-sites'
 import {
   buildCertificatePackScript,
   buildCertificateStateScript,
@@ -318,10 +319,32 @@ describe.skipIf(!canRun)('site:move between two boxes (docker)', () => {
     expect((await exec(SOURCE, `test -f /etc/systemd/system/${SLUG}-${SITE}.service`)).code).toBe(0)
   })
 
+  /**
+   * The drained tree is the rollback, and a teardown would take it. The scan has
+   * to see that on a real box: the site's files present, nothing running for it.
+   */
+  it('is reported as a drained site, so a teardown can refuse', async () => {
+    const scan = await run(SOURCE, buildDrainedSiteScanScript(SLUG).join('\n'))
+    const drained = parseDrainedSites(scan)
+    expect(drained.map(site => site.name)).toContain(SITE)
+    expect(drained[0].size).not.toBe('?')
+  })
+
+  it('is not reported as drained on the target, which is serving it', async () => {
+    const scan = await run(TARGET, buildDrainedSiteScanScript(SLUG).join('\n'))
+    expect(parseDrainedSites(scan)).toEqual([])
+  })
+
   it('comes back on the source by restarting it, with its data intact', async () => {
     await run(SOURCE, `systemctl start ${SLUG}-${SITE}.service`)
     const health = await exec(SOURCE, buildHealthGateScript(PORT, '/'))
     expect(health.code).toBe(0)
     expect((await run(SOURCE, `cat ${APP_BASE}/shared/database/app.sqlite`)).trim()).toBe(SHARED_DB_CONTENT)
+  })
+
+  /** Once the source is serving again, it is no longer holding anyone's rollback. */
+  it('stops being reported as drained once it serves again', async () => {
+    const scan = await run(SOURCE, buildDrainedSiteScanScript(SLUG).join('\n'))
+    expect(parseDrainedSites(scan)).toEqual([])
   })
 })


### PR DESCRIPTION
Refs #167. The last real hole in the move.

## The problem

`site:move` deliberately never deletes anything on the source: it stops the units, drops the gateway route, and leaves the whole tree in place. That leftover tree **is** the rollback — the one thing that makes a bad cutover recoverable, and the reason the operation can promise reversibility *"until the source server is destroyed"*.

Which made destroying that server the moment the promise expires, with nothing anywhere saying so. The box has no running units for the site, so it looks idle; the config has moved on; the operator is tidying up. Terminating it is exactly the right thing to do once the move is verified, and exactly the wrong thing to do before — and from outside those two are identical.

## The fix

`destroy` asks the box whether it is holding anyone's rollback, and refuses:

```
This server still holds 1 site tree with nothing running for it:
  hq-bughq (1.2G)
A site moved off this box keeps its files here on purpose — they are the rollback,
and they are what makes the move reversible until this server is destroyed.
Destroying it now discards that.
Verify the site is serving from its new home first, then re-run with
--discard-drained-sites to destroy it anyway.
```

## Deliberate details

- **Checked before the existing prompt.** An operator answering "yes" to a generic irreversibility warning has not been told that a moved site's only copy is on this disk.
- **`--discard-drained-sites` is its own flag**, not folded into `--force`. `--force` exists so a teardown can run unattended; a CI job skipping a prompt must not also silently discard a rollback.
- **A site with something running is not reported.** That's an ordinary site on a box being torn down, already covered by the existing confirmation. The interesting case is files with nothing running.
- **Only directories holding `releases/` count**, so a stray folder under `/var/www` can't block a teardown the operator genuinely wants.
- **The scan is read-only**, and a box that can't be reached produces a note rather than a block — this exists to stop one specific silent loss, not to stand between an operator and an unreachable server they're trying to be rid of.

## Verification

11 unit tests (scan construction, slug regex escaping, read-only-ness including redirect targets, parsing, the refusal's wording for one vs several).

Plus **3 end-to-end cases against real systemd** — the Docker harness from #180 already leaves a genuinely drained box, so the scan is exercised for free: reported as drained on the source, *not* on the target that's serving it, and no longer drained once the source is restarted. 18 e2e tests passing.

Full suite: **4268 pass, 0 fail.**

## Note on local test failures

If you see ~51 local failures on `main` right now, they're a **stale `packages/core/dist/`** — it predates `resolveMailService`, so the CLI subprocess tests fail to import it. CI builds fresh, which is why it's green. `cd packages/core && bun run build` clears it. Nothing wrong with the code; it cost me a detour, so flagging it.
