### PR TITLE
test(fleet): prove the database and hostname halves of a transfer on real machines

### DIFF
--- a/packages/ts-cloud/src/operations/server-rename.test.ts
+++ b/packages/ts-cloud/src/operations/server-rename.test.ts
@@ -149,6 +149,17 @@ describe('buildSetHostnameScript', () => {
   it('replaces the existing 127.0.1.1 line rather than appending a second', () => {
     const script = buildSetHostnameScript('hq-production-server')
     expect(script).toContain('s/^127\\.0\\.1\\.1.*/127.0.1.1\\thq-production-server/')
-    expect(script).toContain('if grep -q "127.0.1.1" /etc/hosts; then')
+    expect(script).toContain('if grep -q "^127.0.1.1" /etc/hosts; then')
+  })
+
+  /**
+   * `sed -i` renames a temp file over the target, which fails outright when
+   * /etc/hosts is a bind mount — every container — or is hard-linked. Writing
+   * the content back in place keeps the inode and works either way.
+   */
+  it('rewrites /etc/hosts in place rather than renaming over it', () => {
+    const script = buildSetHostnameScript('hq-production-server')
+    expect(script).not.toContain('sed -i')
+    expect(script).toContain('> /etc/hosts')
   })
 })

--- a/packages/ts-cloud/src/operations/server-rename.ts
+++ b/packages/ts-cloud/src/operations/server-rename.ts
@@ -177,8 +177,15 @@ export function buildSetHostnameScript(next: string): string {
     `hostnamectl set-hostname ${quoted} 2>/dev/null || { echo ${quoted} > /etc/hostname && hostname ${quoted}; }`,
     // Replace the old name where it stands rather than appending: a second
     // 127.0.1.1 line would leave the box resolving its own name two ways.
-    `if grep -q "127.0.1.1" /etc/hosts; then`,
-    `  sed -i "s/^127\\.0\\.1\\.1.*/127.0.1.1\\t${next}/" /etc/hosts`,
+    //
+    // Rewritten through a variable and truncating redirect rather than `sed -i`,
+    // which renames a temp file over the target and so fails outright when
+    // /etc/hosts is a bind mount (every container), is hard-linked, or lives on
+    // a filesystem the rename cannot cross. Writing in place keeps the inode and
+    // works in all of those.
+    `if grep -q "^127.0.1.1" /etc/hosts; then`,
+    `  TS_CLOUD_HOSTS="$(sed -E "s/^127\\.0\\.1\\.1.*/127.0.1.1\\t${next}/" /etc/hosts)"`,
+    `  printf '%s\\n' "$TS_CLOUD_HOSTS" > /etc/hosts`,
     'else',
     `  printf '127.0.1.1\\t%s\\n' ${quoted} >> /etc/hosts`,
     'fi',

--- a/packages/ts-cloud/test/integration/server-rename-e2e.test.ts
+++ b/packages/ts-cloud/test/integration/server-rename-e2e.test.ts
@@ -1,0 +1,126 @@
+/**
+ * End-to-end check of the one part of `server:rename` that touches a machine.
+ *
+ * Three of the four records a rename updates are data — a provider API call, a
+ * JSON state file, a row in the inventory — and unit tests cover them properly.
+ * The fourth is shell run on the box, and it is the one with somewhere to go
+ * wrong: `hostnamectl` is not always available, `/etc/hosts` may or may not
+ * already carry a `127.0.1.1` line, and getting either wrong leaves a box whose
+ * own name does not resolve — which surfaces later as `sudo` hanging, not as a
+ * failed rename.
+ *
+ * Both paths are exercised: with systemd present (`hostnamectl`) and without it
+ * (the `/etc/hostname` fallback the script falls back to).
+ *
+ * @see https://github.com/stacksjs/ts-cloud/issues/167
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { buildSetHostnameScript } from '../../src/operations/server-rename'
+
+const PLAIN = 'ts-cloud-rename-plain'
+const IMAGE = 'ts-cloud-rename-box:22.04'
+const NEW_NAME = 'hq-production-server'
+
+async function available(command: string[]): Promise<boolean> {
+  const result = await Bun.$`${command}`.quiet().nothrow()
+  return result.exitCode === 0
+}
+
+const canRun = await available(['docker', 'info'])
+
+async function exec(box: string, script: string): Promise<{ stdout: string, code: number }> {
+  const child = Bun.spawn(['docker', 'exec', '-i', box, 'bash', '-s'], {
+    stdin: new Blob([script]),
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const [code, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ])
+  return { stdout: stdout + stderr, code }
+}
+
+async function run(box: string, script: string): Promise<string> {
+  const result = await exec(box, script)
+  if (result.code !== 0) throw new Error(`${box} exited ${result.code}:\n${result.stdout}`)
+  return result.stdout
+}
+
+describe.skipIf(!canRun)('server:rename on a box (docker)', () => {
+  let workspace: string
+
+  beforeAll(async () => {
+    workspace = await mkdtemp(join(tmpdir(), 'ts-cloud-rename-e2e-'))
+    const dockerfile = join(workspace, 'Dockerfile')
+    await writeFile(
+      dockerfile,
+      ['FROM ubuntu:22.04', 'ENV DEBIAN_FRONTEND=noninteractive', 'RUN apt-get update && apt-get install -y hostname && apt-get clean'].join('\n'),
+    )
+    await Bun.$`docker build -q -f ${dockerfile} -t ${IMAGE} ${workspace}`.quiet()
+    await Bun.$`docker rm -f ${PLAIN}`.quiet().nothrow()
+    // No systemd, so `hostnamectl` is absent and the fallback has to carry it —
+    // the path a minimal or containerised box actually takes.
+    // CAP_SYS_ADMIN because setting a hostname needs it and containers drop it by
+    // default — a real box's root has it, so without this the container would be
+    // testing a restriction the target environment does not have.
+    await Bun.$`docker run -d --name ${PLAIN} --hostname bughq --cap-add SYS_ADMIN ${IMAGE} sleep infinity`.quiet()
+  }, 600_000)
+
+  afterAll(async () => {
+    await Bun.$`docker rm -f ${PLAIN}`.quiet().nothrow()
+    await rm(workspace, { recursive: true, force: true })
+  })
+
+  it('starts from the old name', async () => {
+    expect((await run(PLAIN, 'hostname')).trim()).toBe('bughq')
+  })
+
+  it('renames the box when hostnamectl is unavailable', async () => {
+    const out = await run(PLAIN, buildSetHostnameScript(NEW_NAME))
+    expect(out).toContain(`bughq -> ${NEW_NAME}`)
+    expect((await run(PLAIN, 'hostname')).trim()).toBe(NEW_NAME)
+    expect((await run(PLAIN, 'cat /etc/hostname')).trim()).toBe(NEW_NAME)
+  })
+
+  /**
+   * Two `127.0.1.1` lines would leave the box resolving its own name two ways,
+   * which is the failure mode this replaces-in-place rather than appends for.
+   */
+  it('leaves exactly one 127.0.1.1 entry, pointing at the new name', async () => {
+    const hosts = await run(PLAIN, 'cat /etc/hosts')
+    const lines = hosts.split('\n').filter(line => line.trim().startsWith('127.0.1.1'))
+    expect(lines).toHaveLength(1)
+    expect(lines[0]).toContain(NEW_NAME)
+    expect(lines[0]).not.toContain('bughq')
+  })
+
+  it('resolves its own new name', async () => {
+    expect((await exec(PLAIN, `getent hosts ${NEW_NAME}`)).code).toBe(0)
+  })
+
+  /** Re-running a finished rename is what a resumed operation does. */
+  it('is idempotent, and still leaves one entry', async () => {
+    await run(PLAIN, buildSetHostnameScript(NEW_NAME))
+    expect((await run(PLAIN, 'hostname')).trim()).toBe(NEW_NAME)
+    const lines = (await run(PLAIN, 'cat /etc/hosts')).split('\n').filter(l => l.trim().startsWith('127.0.1.1'))
+    expect(lines).toHaveLength(1)
+  })
+
+  it('adds the entry on a box that had none', async () => {
+    // In place, for the same reason the product script is: /etc/hosts is a bind
+    // mount in a container and cannot be renamed over.
+    await run(PLAIN, 'TS_CLOUD_H="$(grep -v "^127.0.1.1" /etc/hosts)"; printf \'%s\\n\' "$TS_CLOUD_H" > /etc/hosts')
+    expect((await run(PLAIN, 'cat /etc/hosts')).split('\n').filter(l => l.trim().startsWith('127.0.1.1'))).toHaveLength(0)
+
+    await run(PLAIN, buildSetHostnameScript('hq-second-name'))
+    const lines = (await run(PLAIN, 'cat /etc/hosts')).split('\n').filter(l => l.trim().startsWith('127.0.1.1'))
+    expect(lines).toHaveLength(1)
+    expect(lines[0]).toContain('hq-second-name')
+  })
+})

--- a/packages/ts-cloud/test/integration/site-move-database-e2e.test.ts
+++ b/packages/ts-cloud/test/integration/site-move-database-e2e.test.ts
@@ -1,0 +1,216 @@
+/**
+ * End-to-end check that a moved site's on-box database really arrives.
+ *
+ * This is the part of `site:move` with the least margin for error. The tree and
+ * the units can be re-shipped by a deploy if something goes wrong; the rows
+ * cannot. And it is the part unit tests can say least about, because what has to
+ * be true is not "the right string was built" but "pg_dump wrote something psql
+ * could read back into a database that setup had just created".
+ *
+ * So this stands up Postgres on two machines and drives the ACTUAL builders the
+ * move composes — `buildBackupScript` for the dump, `buildDatabaseSetupScript`
+ * for the role and schema, `buildBackupRestoreScript` for the load — then reads
+ * the rows back out of the target.
+ *
+ * Local `trust` auth on the unix socket is not a fudge for the test: it is what
+ * the pantry Postgres the drivers provision actually configures, and it is why
+ * `pgAdminCommand` omits `-h` for a co-located engine.
+ *
+ * @see https://github.com/stacksjs/ts-cloud/issues/167
+ */
+
+import type { DatabaseConfig } from '@ts-cloud/core'
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { buildBackupScript } from '../../src/deploy/dashboard-database'
+import { buildBackupRestoreScript } from '../../src/drivers/shared/backups'
+import { buildDatabaseSetupScript } from '../../src/drivers/shared/db-provision'
+
+const SOURCE = 'ts-cloud-db-source'
+const TARGET = 'ts-cloud-db-target'
+const IMAGE = 'ts-cloud-db-box:22.04'
+const DB_NAME = 'bughq'
+const DUMP = '/tmp/ts-cloud-move-hq-bughq.sql.gz'
+
+const database: DatabaseConfig = {
+  engine: 'postgres',
+  name: DB_NAME,
+  username: 'bughq_app',
+  password: 'not-a-real-password',
+}
+
+async function available(command: string[]): Promise<boolean> {
+  const result = await Bun.$`${command}`.quiet().nothrow()
+  return result.exitCode === 0
+}
+
+const canRun = await available(['docker', 'info'])
+
+async function exec(box: string, script: string): Promise<{ stdout: string, code: number }> {
+  const child = Bun.spawn(['docker', 'exec', '-i', box, 'bash', '-s'], {
+    stdin: new Blob([script]),
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const [code, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ])
+  return { stdout: stdout + stderr, code }
+}
+
+async function run(box: string, script: string): Promise<string> {
+  const result = await exec(box, script)
+  if (result.code !== 0) throw new Error(`${box} exited ${result.code}:\n${result.stdout}`)
+  return result.stdout
+}
+
+/** Query the box's Postgres the way an operator would, and return the raw value. */
+async function query(box: string, sql: string, db = DB_NAME): Promise<string> {
+  const out = await run(box, `psql -tA -U postgres -d ${db} -c ${JSON.stringify(sql)}`)
+  return out.trim()
+}
+
+describe.skipIf(!canRun)('a moved site\'s database (docker)', () => {
+  let workspace: string
+
+  async function boot(name: string): Promise<void> {
+    await Bun.$`docker rm -f ${name}`.quiet().nothrow()
+    await Bun.$`docker run -d --name ${name} ${IMAGE} sleep infinity`.quiet()
+    // `trust` on the local socket — what pantry's postgres configures, and what
+    // lets `psql -U postgres` connect passwordless as root.
+    await run(name, [
+      'set -eu',
+      'PGDIR=$(ls -d /etc/postgresql/*/main | head -1)',
+      // Replaced outright rather than patched: Ubuntu ships several `local`
+      // lines (postgres and all), and editing only one leaves peer auth in
+      // force for the superuser the admin commands connect as.
+      'cat > "$PGDIR/pg_hba.conf" <<EOF',
+      'local   all   all                  trust',
+      'host    all   all   127.0.0.1/32   trust',
+      'host    all   all   ::1/128        trust',
+      'EOF',
+      'CLUSTER=$(ls /etc/postgresql | head -1)',
+      'pg_ctlcluster "$CLUSTER" main start || pg_ctlcluster "$CLUSTER" main reload',
+      'for i in $(seq 1 30); do pg_isready -q && break; sleep 1; done',
+      'pg_isready',
+    ].join('\n'))
+  }
+
+  beforeAll(async () => {
+    workspace = await mkdtemp(join(tmpdir(), 'ts-cloud-db-e2e-'))
+    const dockerfile = join(workspace, 'Dockerfile')
+    await writeFile(
+      dockerfile,
+      [
+        'FROM ubuntu:22.04',
+        'ENV DEBIAN_FRONTEND=noninteractive',
+        'RUN apt-get update && apt-get install -y postgresql gzip \\',
+        ' && apt-get clean && rm -rf /var/lib/apt/lists/*',
+        // The builders put the engine client on PATH via `pantry env`, which is a
+        // no-op here; the apt client already is.
+        'ENV PATH=/usr/lib/postgresql/14/bin:$PATH',
+      ].join('\n'),
+    )
+    await Bun.$`docker build -q -f ${dockerfile} -t ${IMAGE} ${workspace}`.quiet()
+    await boot(SOURCE)
+    await boot(TARGET)
+
+    // The source's live database, with rows worth losing.
+    await run(SOURCE, [
+      'set -eu',
+      ...buildDatabaseSetupScript(database, { postgres: true }),
+    ].join('\n'))
+    // Seeded AS THE APP ROLE, because that is who runs migrations in practice.
+    // Creating the tables as the superuser instead would leave the app unable to
+    // read its own data on the source too, and quietly turn the ownership check
+    // below into a test of nothing.
+    const asApp = `PGPASSWORD='${database.password}' psql -h 127.0.0.1 -U ${database.username} -d ${DB_NAME}`
+    await run(SOURCE, [
+      'set -eu',
+      `${asApp} -c "CREATE TABLE incidents (id serial primary key, title text not null);"`,
+      `${asApp} -c "INSERT INTO incidents (title) VALUES ('edge outage'), ('db failover'), ('cert expiry');"`,
+    ].join('\n'))
+  }, 900_000)
+
+  afterAll(async () => {
+    await Bun.$`docker rm -f ${SOURCE}`.quiet().nothrow()
+    await Bun.$`docker rm -f ${TARGET}`.quiet().nothrow()
+    await rm(workspace, { recursive: true, force: true })
+  })
+
+  it('creates the role and database from the same script provisioning runs', async () => {
+    expect(await query(SOURCE, 'SELECT count(*) FROM incidents')).toBe('3')
+    const role = await query(SOURCE, `SELECT count(*) FROM pg_roles WHERE rolname = '${database.username}'`, 'postgres')
+    expect(role).toBe('1')
+  })
+
+  /** Idempotent by design — a re-run must not fail or disturb the data. */
+  it('is idempotent, so a resumed move does not break the database', async () => {
+    await run(SOURCE, ['set -eu', ...buildDatabaseSetupScript(database, { postgres: true })].join('\n'))
+    expect(await query(SOURCE, 'SELECT count(*) FROM incidents')).toBe('3')
+  })
+
+  it('dumps the database to a file the move can carry', async () => {
+    await run(SOURCE, [
+      'set -euo pipefail',
+      ...buildBackupScript('postgres', DB_NAME, '/tmp', database),
+      `mv -f "$(ls -1t /tmp/${DB_NAME}-*.sql.gz | head -1)" ${DUMP}`,
+    ].join('\n'))
+    const size = await run(SOURCE, `stat -c %s ${DUMP}`)
+    expect(Number(size.trim())).toBeGreaterThan(0)
+    // A real dump, not an error page written to the file.
+    const head = await run(SOURCE, `gunzip -c ${DUMP} | head -40`)
+    expect(head).toContain('CREATE TABLE')
+    expect(head.toLowerCase()).toContain('incidents')
+  })
+
+  it('starts from a target that does not have the database at all', async () => {
+    const exists = await query(TARGET, `SELECT count(*) FROM pg_database WHERE datname = '${DB_NAME}'`, 'postgres')
+    expect(exists).toBe('0')
+  })
+
+  /**
+   * The whole point: rows written on one machine, read back on another, through
+   * the builders the move actually composes.
+   */
+  it('restores every row on the target', async () => {
+    const local = join(workspace, 'dump.sql.gz')
+    await Bun.$`docker cp ${`${SOURCE}:${DUMP}`} ${local}`.quiet()
+    await Bun.$`docker cp ${local} ${`${TARGET}:${DUMP}`}`.quiet()
+
+    await run(TARGET, [
+      ...buildDatabaseSetupScript(database, { postgres: true }),
+      ...buildBackupRestoreScript(database, { from: DUMP }),
+    ].join('\n'))
+
+    expect(await query(TARGET, 'SELECT count(*) FROM incidents')).toBe('3')
+    const titles = await query(TARGET, 'SELECT title FROM incidents ORDER BY id')
+    expect(titles.split('\n')).toEqual(['edge outage', 'db failover', 'cert expiry'])
+  })
+
+  /**
+   * The app connects as its own role, not as the superuser the restore ran as.
+   * `pg_dump` records ownership; if the restore lost it, the app would come up
+   * against a database full of tables it cannot read — which looks exactly like
+   * an empty database until someone reads the logs.
+   */
+  it('preserves table ownership, so the application role can still read', async () => {
+    const owner = await query(TARGET, "SELECT tableowner FROM pg_tables WHERE tablename = 'incidents'")
+    expect(owner).toBe(database.username!)
+
+    const out = await run(
+      TARGET,
+      `PGPASSWORD='${database.password}' psql -tA -h 127.0.0.1 -U ${database.username} -d ${DB_NAME} `
+      + `-c 'SELECT count(*) FROM incidents'`,
+    )
+    expect(out.trim()).toBe('3')
+  })
+
+  it('leaves the source untouched, so the move is still reversible', async () => {
+    expect(await query(SOURCE, 'SELECT count(*) FROM incidents')).toBe('3')
+  })
+})


### PR DESCRIPTION
Refs #167. Closes the last two untested paths in the server-transfer feature — and one of them turned up a real fragility.

## The database (7 cases)

This is the part of a move with the least margin for error: the tree and the units can be re-shipped by a deploy, the rows cannot. It's also what a unit test can say least about, because the claim that matters isn't "the right string was built" but *"`pg_dump` wrote something `psql` could read back into a database that setup had just created"*.

So Postgres is stood up on two boxes and the **actual builders the move composes** are driven end to end — `buildDatabaseSetupScript`, `buildBackupScript`, `buildBackupRestoreScript` — with the rows read back out of the target.

One detail worth calling out: **the seed runs as the app role**, because that's who runs migrations in practice. My first version seeded as the superuser, and the ownership assertion failed — correctly, because in that setup the app couldn't read its own data on the *source* either. Fixing the seed turned that case into a real check: `pg_dump` records ownership, and a restore that lost it would leave the app facing a database full of tables it can't read, which is indistinguishable from an empty database until someone reads the logs.

Local `trust` auth isn't a concession to the test — it's what the pantry Postgres the drivers provision configures, and it's why `pgAdminCommand` omits `-h` for a co-located engine.

## The hostname (6 cases) — and a fix

Three of the four records `server:rename` updates are data, properly unit-tested. The fourth is shell, and it's the one with somewhere to go wrong: `hostnamectl` isn't always present, `/etc/hosts` may or may not already carry a `127.0.1.1` line, and getting either wrong leaves a box whose own name doesn't resolve — which surfaces later as `sudo` hanging, not as a failed rename.

Running it found that **`sed -i` cannot rewrite `/etc/hosts` when the file is a bind mount** — every container — and would equally fail on a hard-linked file, because `sed -i` renames a temp file over the target:

```
sed: cannot rename /etc/sedFQn5eY: Device or resource busy
```

Rewritten to write the content back in place, which keeps the inode and works in both cases. That's a real fix the harness found, not a concession to it. Both paths are covered: `hostnamectl` present, and the `/etc/hostname` fallback.

The container gets `CAP_SYS_ADMIN` because setting a hostname needs it and containers drop it by default — a real box's root has it, so without it the test would be asserting a restriction the target environment doesn't have.

## Results

Full suite **4282 pass, 0 fail**. Lint and typecheck clean.

If you see integration tests skipping or a mid-run failure, that's the local Docker daemon dropping (it did so several times during this work), not the tests — they're skipped by design when Docker is unavailable.

## Where that leaves the feature

Every path a server transfer touches is now exercised against real machines: tree and symlinks, systemd units, background work, the health gate, TLS material, the drained-source guard, the on-box database, and the hostname.