### PR TITLE
fix(ui): stop passing a type argument to a chart helper that has none

### DIFF
--- a/packages/ui/src/charts.ts
+++ b/packages/ui/src/charts.ts
@@ -111,8 +111,11 @@ export function renderDeploymentSparkline(records: DeploymentPoint[]): string {
     record,
   }))
 
+  // `line` is not generic: @ts-charts/shape declares it
+  // `createLine(x?: any, y?: any): any`, so the accessors below carry the
+  // typing instead. It was generic before 0.2.x.
   const path =
-    line<any>()
+    line()
       .x((d: any) => d.x)
       .y((d: any) => d.y)
       .curve(curveMonotoneX)(buckets) ?? ''


### PR DESCRIPTION
Fixes the typecheck failure blocking #181.

## What's wrong

`@ts-charts/shape` declares `line` as:

```ts
export default function createLine(x?: any, y?: any): any;
```

Not generic. So `line<any>()` in `packages/ui/src/charts.ts` is a type error against 0.2.x:

```
packages/ui/src/charts.ts(115,10): error TS2558: Expected 0 type arguments, but got 1.
```

The pinned `0.2.0` still had it generic, which is why this only shows up on the dependency-update branch and not on `main`.

## Why here and not on #181's branch

Dropping the type argument rather than pinning the dependency back, because a type argument on a generic is **optional** — so this compiles against both the pinned version and the update. I verified both: typecheck passes with `0.2.0` installed *and* with `0.2.7` installed.

Landing it on `main` rather than pushing into Renovate's branch means #181 goes green on its next rebase, instead of the fix living in a branch Renovate owns and will rewrite.

The accessors below the call already carry the typing (`.x((d: any) => d.x)`), so nothing is lost by removing it.

## Checked

I grepped for every other generic call site into that package — `area<`, `stack<`, `scaleBand<`, `scaleLinear<`, `pie<`, `arc<`, `symbol<`, `radialLine<` — and this is the only one. So #181 should have no second failure behind this one.

Typecheck and lint clean; full suite green on both dependency versions (4117 pass / 0 fail on the update branch, which is stale and so runs fewer tests than `main`).