### PR TITLE
fix(db): name a dump once, so the file written is the file reported

### DIFF
--- a/packages/ts-cloud/src/deploy/dashboard-database.test.ts
+++ b/packages/ts-cloud/src/deploy/dashboard-database.test.ts
@@ -119,7 +119,7 @@ describe('buildListScript + parseDbList', () => {
   it('builds a per-database dump script (mysqldump / pg_dump) to a timestamped file', () => {
     const my = buildBackupScript('mysql', 'acme').join('\n')
     expect(my).toContain('mysqldump --socket=')
-    expect(my).toContain('acme-$(date +%Y%m%d-%H%M%S).sql.gz')
+    expect(my).toContain('acme-$TS_CLOUD_BACKUP_STAMP.sql.gz')
     // Local pantry engine: socket (no -h) — TCP loopback demands md5.
     const pg = buildBackupScript('postgres', 'acme').join('\n')
     expect(pg).toContain('pg_dump -p 5432 -U postgres acme')
@@ -134,6 +134,32 @@ describe('buildListScript + parseDbList', () => {
     }).join('\n')
     expect(ext).toContain(`PGPASSWORD='pw' pg_dump -h db.example.com -p 5432 -U admin -w acme`)
   })
+
+  /**
+   * The timestamp has to be taken ONCE. Written inline as `$(date …)` it runs
+   * again in every command that mentions the filename, so a dump crossing a
+   * second boundary writes one file and then reports — and lists — a different
+   * one that does not exist: a backup that succeeds and names a path nobody can
+   * find. Caught on CI by the docker end-to-end test, which is slower than a
+   * laptop and so actually crossed the boundary.
+   */
+  it('names the dump once, so the file it writes is the file it reports', () => {
+    for (const engine of ['postgres', 'mysql', 'mariadb'] as const) {
+      const script = buildBackupScript(engine, 'acme')
+      expect(script.filter(line => line.includes('$(date'))).toHaveLength(1)
+      expect(script.some(line => line.startsWith('TS_CLOUD_BACKUP_STAMP='))).toBe(true)
+
+      // The write, the report and the listing must all name the same thing.
+      const named = script.filter(line => line.includes('acme-'))
+      expect(named).toHaveLength(3)
+      for (const line of named) expect(line).toContain('acme-$TS_CLOUD_BACKUP_STAMP.sql.gz')
+
+      // And the stamp is set before anything uses it.
+      expect(script.findIndex(l => l.startsWith('TS_CLOUD_BACKUP_STAMP=')))
+        .toBeLessThan(script.findIndex(l => l.includes('acme-$TS_CLOUD_BACKUP_STAMP')))
+    }
+  })
+
 
   it('parses BACKUP= lines into database + file, deriving the db from the filename', () => {
     const parsed = parseBackups(

--- a/packages/ts-cloud/src/deploy/dashboard-database.ts
+++ b/packages/ts-cloud/src/deploy/dashboard-database.ts
@@ -440,11 +440,19 @@ export function buildBackupScript(
   destDir: string = DB_BACKUP_DIR,
   database?: DatabaseConfig,
 ): string[] {
-  const file = `${destDir}/${name}-$(date +%Y%m%d-%H%M%S).sql.gz`
+  // The timestamp is taken ONCE into a variable rather than embedded as a
+  // command substitution. Written inline, `$(date …)` runs again in every
+  // command that mentions the filename — so a dump that happens to cross a
+  // second boundary writes one file and then reports, and lists, a different
+  // one that does not exist. The backup succeeds and names a path nobody can
+  // find, which is the worst way for a backup to fail.
+  const stamp = 'TS_CLOUD_BACKUP_STAMP="$(date +%Y%m%d-%H%M%S)"'
+  const file = `${destDir}/${name}-$TS_CLOUD_BACKUP_STAMP.sql.gz`
   const mkdir = `mkdir -p ${destDir}`
   if (engine === 'postgres')
     return [
       mkdir,
+      stamp,
       `${pgAdminCommand(database, 'pg_dump')} ${name} | gzip > "${file}"`,
       `echo "BACKUP=${file}"`,
       `ls -l "${file}"`,
@@ -452,6 +460,7 @@ export function buildBackupScript(
   const sock = engine === 'mariadb' ? SOCKETS.mariadb : SOCKETS.mysql
   return [
     mkdir,
+    stamp,
     `mysqldump --socket=${sock} -u root ${name} | gzip > "${file}"`,
     `echo "BACKUP=${file}"`,
     `ls -l "${file}"`,


### PR DESCRIPTION
A real bug, found by the end-to-end test from #184. It's currently making `main`'s CI red.

## What's wrong

`buildBackupScript` embedded the timestamp as a command substitution inside the filename:

```
/var/backups/ts-cloud/databases/<name>-$(date +%Y%m%d-%H%M%S).sql.gz
```

The commands run in **one shell**, so that substitution is evaluated *again* in every command that mentions the path — once for the redirect that creates the dump, again for `echo "BACKUP=…"`, again for the `ls`. A dump that crosses a second boundary writes one file and then reports, and lists, a different one:

```
BACKUP=/tmp/bughq-20260824-163357.sql.gz
ls: cannot access '/tmp/bughq-20260824-163357.sql.gz': No such file or directory
```

## Why it matters

The failure mode is the bad kind. The dump itself is **fine and sitting on disk**; `db:backup` just reports the wrong path for it. Anything parsing `BACKUP=` gets a filename that isn't there, the closing `ls` fails against a backup that actually succeeded, and `site:move` — which locates the dump it's about to carry — can't find it.

## The fix

Take the timestamp once into a variable. Same shell, so it holds across the commands, and postgres/mysql/mariadb all route through it.

## How it surfaced

The Docker end-to-end test added in #184 runs on CI hardware slower than a laptop, so it actually crossed the second boundary. Every local run of that same test passed. That's the harness doing exactly what it was built for — this is a latent bug that predates all of this work and would otherwise have shown up as a mystifying "backup succeeded but the file isn't there" in production.

The unit regression test asserts the **property**, not the symptom: exactly one `$(date` in the script, and the write, the report and the listing all naming the same thing, checked across all three engines.

## Verification

31 unit tests in `dashboard-database.test.ts` and the 7 database e2e cases both green locally.

Note this also unblocks #185 (and therefore #181) — their `test` job is failing on this, not on anything in those changes.